### PR TITLE
  feat: add explore/discovery page with search, filtering, sorting, and group preview modal

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -106,6 +106,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1592,7 +1593,8 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
       "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai-subset": {
       "version": "1.3.6",
@@ -1694,6 +1696,7 @@
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1711,6 +1714,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1775,6 +1779,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2163,6 +2168,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2561,6 +2567,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2889,7 +2896,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -3376,6 +3384,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4577,6 +4586,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5289,6 +5299,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5531,6 +5542,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5543,6 +5555,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6467,6 +6480,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6607,6 +6621,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6744,6 +6759,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -6828,6 +6844,7 @@
       "integrity": "sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,8 +9,9 @@ import { GroupAnalytics } from '@/components/GroupAnalytics'
 import { ResponsiveLayout } from '@/components/ResponsiveLayout'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { Tutorial } from '@/components/Tutorial'
+import { Explore } from '@/pages/Explore'
 
-type ViewType = 'dashboard' | 'create' | 'detail' | 'analytics' | 'responsive'
+type ViewType = 'dashboard' | 'create' | 'detail' | 'analytics' | 'responsive' | 'explore'
 
 function App() {
   const [currentView, setCurrentView] = useState<ViewType>('dashboard')
@@ -85,6 +86,16 @@ function App() {
             >
               Responsive Demo
             </button>
+            <button
+              onClick={() => setCurrentView('explore')}
+              className={`px-4 py-2 rounded font-semibold transition ${
+                currentView === 'explore'
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white text-gray-700 hover:bg-gray-100'
+              }`}
+            >
+              Explore
+            </button>
           </div>
         </div>
 
@@ -109,6 +120,8 @@ function App() {
             {currentView === 'analytics' && <GroupAnalytics />}
 
             {currentView === 'responsive' && <ResponsiveLayout />}
+
+            {currentView === 'explore' && <Explore />}
           </ErrorBoundary>
         </main>
 

--- a/frontend/src/components/GroupExplorer.tsx
+++ b/frontend/src/components/GroupExplorer.tsx
@@ -1,0 +1,508 @@
+import React, { useState } from 'react'
+import { useExplore, ALL_TAGS, ExploreGroup, ExploreSortField } from '@/hooks/useExplore'
+import { GroupPreviewModal } from '@/components/GroupPreviewModal'
+
+const tagColors: Record<string, string> = {
+  savings: 'bg-blue-100 text-blue-700',
+  housing: 'bg-orange-100 text-orange-700',
+  education: 'bg-purple-100 text-purple-700',
+  emergency: 'bg-red-100 text-red-700',
+  business: 'bg-green-100 text-green-700',
+  vacation: 'bg-cyan-100 text-cyan-700',
+  family: 'bg-pink-100 text-pink-700',
+  community: 'bg-indigo-100 text-indigo-700',
+}
+
+const statusColors = {
+  active: 'bg-green-100 text-green-800 border-green-200',
+  completed: 'bg-blue-100 text-blue-800 border-blue-200',
+  paused: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+}
+
+const sortLabels: Record<ExploreSortField, string> = {
+  popularity: 'Popularity',
+  createdAt: 'Newest',
+  members: 'Most Members',
+  amount: 'Amount',
+  totalRaised: 'Total Raised',
+}
+
+function ExploreCard({ group, onClick }: { group: ExploreGroup; onClick: () => void }) {
+  const fillPercent = (group.currentMembers / group.maxMembers) * 100
+  const isFull = group.currentMembers >= group.maxMembers
+
+  return (
+    <div
+      className="card-interactive flex flex-col gap-3 h-full"
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={e => e.key === 'Enter' && onClick()}
+      aria-label={`View details for ${group.name}`}
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="font-bold text-gray-900 text-base leading-snug line-clamp-2">{group.name}</h3>
+        <span className={`px-2.5 py-0.5 rounded-full text-xs font-semibold border flex-shrink-0 ${statusColors[group.status]}`}>
+          {group.status.charAt(0).toUpperCase() + group.status.slice(1)}
+        </span>
+      </div>
+
+      {/* Description */}
+      <p className="text-sm text-gray-500 line-clamp-2 leading-relaxed flex-1">
+        {group.description}
+      </p>
+
+      {/* Tags */}
+      <div className="flex flex-wrap gap-1.5">
+        {group.tags.map(tag => (
+          <span key={tag} className={`px-2 py-0.5 rounded text-xs font-medium ${tagColors[tag] ?? 'bg-gray-100 text-gray-600'}`}>
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      {/* Stats row */}
+      <div className="grid grid-cols-2 gap-2 text-sm">
+        <div className="bg-gray-50 rounded-lg px-3 py-2">
+          <p className="text-xs text-gray-400 font-medium">Contribution</p>
+          <p className="font-bold text-gray-900">${group.contributionAmount}<span className="text-xs text-gray-400 font-normal">/{group.frequency === 'weekly' ? 'wk' : 'mo'}</span></p>
+        </div>
+        <div className="bg-gray-50 rounded-lg px-3 py-2">
+          <p className="text-xs text-gray-400 font-medium">Total Raised</p>
+          <p className="font-bold text-gray-900">${group.totalRaised.toLocaleString()}</p>
+        </div>
+      </div>
+
+      {/* Members progress */}
+      <div>
+        <div className="flex justify-between items-center mb-1">
+          <span className="text-xs text-gray-500">Members</span>
+          <span className={`text-xs font-semibold ${isFull ? 'text-red-600' : 'text-gray-700'}`}>
+            {group.currentMembers}/{group.maxMembers}
+          </span>
+        </div>
+        <div className="w-full bg-gray-200 rounded-full h-1.5 overflow-hidden">
+          <div
+            className={`h-1.5 rounded-full transition-all ${isFull ? 'bg-red-400' : fillPercent >= 80 ? 'bg-orange-400' : 'bg-blue-600'}`}
+            style={{ width: `${fillPercent}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between pt-1 border-t border-gray-100">
+        <div className="flex items-center gap-1">
+          <svg className="w-3.5 h-3.5 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
+            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+          </svg>
+          <span className="text-xs text-gray-500">{group.creatorReputation.toFixed(1)} creator</span>
+        </div>
+        {group.isJoined ? (
+          <span className="text-xs font-semibold text-green-600 flex items-center gap-1">
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+            Joined
+          </span>
+        ) : (
+          <span className="text-xs font-semibold text-blue-600">View Details →</span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function FilterPanel({
+  filters,
+  updateFilters,
+  resetFilters,
+  onClose,
+}: {
+  filters: ReturnType<typeof useExplore>['filters']
+  updateFilters: ReturnType<typeof useExplore>['updateFilters']
+  resetFilters: () => void
+  onClose?: () => void
+}) {
+  const hasActiveFilters =
+    filters.minAmount !== '' ||
+    filters.maxAmount !== '' ||
+    filters.minMembers !== '' ||
+    filters.maxMembers !== '' ||
+    filters.minDuration !== '' ||
+    filters.maxDuration !== '' ||
+    filters.status !== 'all' ||
+    filters.frequency !== 'all' ||
+    filters.tags.length > 0
+
+  const toggleTag = (tag: string) => {
+    const current = filters.tags
+    updateFilters({ tags: current.includes(tag) ? current.filter(t => t !== tag) : [...current, tag] })
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold text-gray-900">Filters</h3>
+        {hasActiveFilters && (
+          <button
+            onClick={resetFilters}
+            className="text-xs text-blue-600 hover:text-blue-800 font-medium transition-colors"
+          >
+            Clear all
+          </button>
+        )}
+        {onClose && (
+          <button onClick={onClose} className="p-1 text-gray-400 hover:text-gray-600 transition-colors">
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      {/* Status */}
+      <div>
+        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Status</label>
+        <div className="flex flex-wrap gap-2">
+          {(['all', 'active', 'paused', 'completed'] as const).map(s => (
+            <button
+              key={s}
+              onClick={() => updateFilters({ status: s })}
+              className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors ${
+                filters.status === s
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {s === 'all' ? 'All' : s.charAt(0).toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Frequency */}
+      <div>
+        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Frequency</label>
+        <div className="flex gap-2">
+          {(['all', 'weekly', 'monthly'] as const).map(f => (
+            <button
+              key={f}
+              onClick={() => updateFilters({ frequency: f })}
+              className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors flex-1 ${
+                filters.frequency === f
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {f === 'all' ? 'All' : f.charAt(0).toUpperCase() + f.slice(1)}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Amount Range */}
+      <div>
+        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Contribution Amount ($)</label>
+        <div className="flex gap-2 items-center">
+          <input
+            type="number"
+            placeholder="Min"
+            min={0}
+            value={filters.minAmount}
+            onChange={e => updateFilters({ minAmount: e.target.value === '' ? '' : Number(e.target.value) })}
+            className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 placeholder-gray-400 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+          <span className="text-gray-400 text-sm flex-shrink-0">–</span>
+          <input
+            type="number"
+            placeholder="Max"
+            min={0}
+            value={filters.maxAmount}
+            onChange={e => updateFilters({ maxAmount: e.target.value === '' ? '' : Number(e.target.value) })}
+            className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 placeholder-gray-400 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+      </div>
+
+      {/* Members Range */}
+      <div>
+        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Max Members</label>
+        <div className="flex gap-2 items-center">
+          <input
+            type="number"
+            placeholder="Min"
+            min={1}
+            value={filters.minMembers}
+            onChange={e => updateFilters({ minMembers: e.target.value === '' ? '' : Number(e.target.value) })}
+            className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 placeholder-gray-400 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+          <span className="text-gray-400 text-sm flex-shrink-0">–</span>
+          <input
+            type="number"
+            placeholder="Max"
+            min={1}
+            value={filters.maxMembers}
+            onChange={e => updateFilters({ maxMembers: e.target.value === '' ? '' : Number(e.target.value) })}
+            className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 placeholder-gray-400 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+      </div>
+
+      {/* Duration Range */}
+      <div>
+        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Duration (cycles)</label>
+        <div className="flex gap-2 items-center">
+          <input
+            type="number"
+            placeholder="Min"
+            min={1}
+            value={filters.minDuration}
+            onChange={e => updateFilters({ minDuration: e.target.value === '' ? '' : Number(e.target.value) })}
+            className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 placeholder-gray-400 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+          <span className="text-gray-400 text-sm flex-shrink-0">–</span>
+          <input
+            type="number"
+            placeholder="Max"
+            min={1}
+            value={filters.maxDuration}
+            onChange={e => updateFilters({ maxDuration: e.target.value === '' ? '' : Number(e.target.value) })}
+            className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm text-gray-900 placeholder-gray-400 bg-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+      </div>
+
+      {/* Tags */}
+      <div>
+        <label className="block text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">Categories</label>
+        <div className="flex flex-wrap gap-2">
+          {ALL_TAGS.map(tag => (
+            <button
+              key={tag}
+              onClick={() => toggleTag(tag)}
+              className={`px-2.5 py-1 rounded-lg text-xs font-medium transition-colors border ${
+                filters.tags.includes(tag)
+                  ? `${tagColors[tag] ?? 'bg-gray-100 text-gray-700'} border-current`
+                  : 'bg-white text-gray-600 border-gray-200 hover:border-gray-400'
+              }`}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const GroupExplorer: React.FC = () => {
+  const {
+    paginatedGroups,
+    filters,
+    updateFilters,
+    resetFilters,
+    sort,
+    setSort,
+    page,
+    setPage,
+    totalPages,
+    totalCount,
+    joinGroup,
+  } = useExplore()
+
+  const [selectedGroup, setSelectedGroup] = useState<ExploreGroup | null>(null)
+  const [filtersOpen, setFiltersOpen] = useState(false)
+
+  const handleSortField = (field: ExploreSortField) => {
+    if (sort.field === field) {
+      setSort({ field, direction: sort.direction === 'desc' ? 'asc' : 'desc' })
+    } else {
+      setSort({ field, direction: 'desc' })
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Search Bar */}
+      <div className="relative">
+        <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+          <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+        </div>
+        <input
+          type="text"
+          placeholder="Search by group name or creator address..."
+          value={filters.search}
+          onChange={e => updateFilters({ search: e.target.value })}
+          className="w-full pl-12 pr-4 py-3.5 border border-gray-300 rounded-xl text-base text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent shadow-sm bg-white"
+        />
+        {filters.search && (
+          <button
+            onClick={() => updateFilters({ search: '' })}
+            className="absolute inset-y-0 right-0 pr-4 flex items-center text-gray-400 hover:text-gray-600"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        )}
+      </div>
+
+      <div className="flex gap-6">
+        {/* Filter Sidebar - desktop */}
+        <aside className="hidden lg:block w-64 flex-shrink-0">
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5 sticky top-24">
+            <FilterPanel filters={filters} updateFilters={updateFilters} resetFilters={resetFilters} />
+          </div>
+        </aside>
+
+        {/* Main content */}
+        <div className="flex-1 min-w-0 space-y-4">
+          {/* Toolbar */}
+          <div className="flex flex-wrap items-center gap-3 bg-white rounded-xl px-4 py-3 shadow-sm border border-gray-100">
+            {/* Mobile filter toggle */}
+            <button
+              onClick={() => setFiltersOpen(true)}
+              className="lg:hidden flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+              </svg>
+              Filters
+            </button>
+
+            <p className="text-sm text-gray-500">
+              <span className="font-semibold text-gray-800">{totalCount}</span> group{totalCount !== 1 ? 's' : ''} found
+            </p>
+
+            <div className="flex-1" />
+
+            {/* Sort */}
+            <div className="flex items-center gap-2">
+              <span className="text-xs text-gray-500 hidden sm:inline font-medium">Sort:</span>
+              <div className="flex gap-1 flex-wrap">
+                {(Object.keys(sortLabels) as ExploreSortField[]).map(field => (
+                  <button
+                    key={field}
+                    onClick={() => handleSortField(field)}
+                    className={`px-2.5 py-1.5 rounded-lg text-xs font-semibold transition-colors flex items-center gap-1 ${
+                      sort.field === field
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                    }`}
+                  >
+                    {sortLabels[field]}
+                    {sort.field === field && (
+                      <span>{sort.direction === 'desc' ? '↓' : '↑'}</span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Group Grid */}
+          {paginatedGroups.length === 0 ? (
+            <div className="text-center py-16 bg-white rounded-xl border border-gray-100 shadow-sm">
+              <svg className="w-12 h-12 text-gray-300 mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              <p className="text-gray-500 font-medium">No groups match your filters</p>
+              <button
+                onClick={resetFilters}
+                className="mt-3 text-sm text-blue-600 hover:text-blue-800 font-medium transition-colors"
+              >
+                Clear all filters
+              </button>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+              {paginatedGroups.map(group => (
+                <ExploreCard
+                  key={group.id}
+                  group={group}
+                  onClick={() => setSelectedGroup(group)}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 pt-2">
+              <button
+                onClick={() => setPage(Math.max(1, page - 1))}
+                disabled={page === 1}
+                className="px-3 py-2 rounded-lg border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                aria-label="Previous page"
+              >
+                ←
+              </button>
+
+              {Array.from({ length: totalPages }, (_, i) => i + 1).map(p => {
+                const isEllipsis = totalPages > 7 && Math.abs(p - page) > 2 && p !== 1 && p !== totalPages
+                const showEllipsis =
+                  totalPages > 7 &&
+                  ((p === 2 && page > 4) || (p === totalPages - 1 && page < totalPages - 3))
+
+                if (isEllipsis && !showEllipsis) return null
+                if (showEllipsis) {
+                  return <span key={p} className="px-1 text-gray-400">…</span>
+                }
+
+                return (
+                  <button
+                    key={p}
+                    onClick={() => setPage(p)}
+                    className={`w-9 h-9 rounded-lg text-sm font-semibold transition-colors ${
+                      page === p
+                        ? 'bg-blue-600 text-white shadow-sm'
+                        : 'border border-gray-300 text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    {p}
+                  </button>
+                )
+              })}
+
+              <button
+                onClick={() => setPage(Math.min(totalPages, page + 1))}
+                disabled={page === totalPages}
+                className="px-3 py-2 rounded-lg border border-gray-300 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                aria-label="Next page"
+              >
+                →
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Mobile Filter Drawer */}
+      {filtersOpen && (
+        <div className="fixed inset-0 z-50 lg:hidden">
+          <div className="absolute inset-0 bg-black/40" onClick={() => setFiltersOpen(false)} />
+          <div className="absolute right-0 top-0 bottom-0 w-80 bg-white shadow-xl overflow-y-auto p-5">
+            <FilterPanel
+              filters={filters}
+              updateFilters={updateFilters}
+              resetFilters={resetFilters}
+              onClose={() => setFiltersOpen(false)}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Preview Modal */}
+      {selectedGroup && (
+        <GroupPreviewModal
+          group={selectedGroup}
+          onClose={() => setSelectedGroup(null)}
+          onJoin={id => { joinGroup(id); setSelectedGroup(null) }}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/GroupPreviewModal.tsx
+++ b/frontend/src/components/GroupPreviewModal.tsx
@@ -1,0 +1,257 @@
+import React, { useEffect } from 'react'
+import { ExploreGroup } from '@/hooks/useExplore'
+
+interface GroupPreviewModalProps {
+  group: ExploreGroup
+  onClose: () => void
+  onJoin: (groupId: string) => void
+}
+
+function StarRating({ value }: { value: number }) {
+  return (
+    <span className="flex items-center gap-0.5">
+      {[1, 2, 3, 4, 5].map(star => {
+        const filled = value >= star
+        const half = !filled && value >= star - 0.5
+        return (
+          <svg key={star} className={`w-4 h-4 ${filled || half ? 'text-yellow-400' : 'text-gray-300'}`} fill="currentColor" viewBox="0 0 20 20">
+            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+          </svg>
+        )
+      })}
+      <span className="ml-1 text-sm text-gray-600 font-medium">{value.toFixed(1)}</span>
+    </span>
+  )
+}
+
+const statusColors = {
+  active: 'bg-green-100 text-green-800 border-green-200',
+  completed: 'bg-blue-100 text-blue-800 border-blue-200',
+  paused: 'bg-yellow-100 text-yellow-800 border-yellow-200',
+}
+
+const tagColors: Record<string, string> = {
+  savings: 'bg-blue-100 text-blue-700',
+  housing: 'bg-orange-100 text-orange-700',
+  education: 'bg-purple-100 text-purple-700',
+  emergency: 'bg-red-100 text-red-700',
+  business: 'bg-green-100 text-green-700',
+  vacation: 'bg-cyan-100 text-cyan-700',
+  family: 'bg-pink-100 text-pink-700',
+  community: 'bg-indigo-100 text-indigo-700',
+}
+
+export const GroupPreviewModal: React.FC<GroupPreviewModalProps> = ({ group, onClose, onJoin }) => {
+  const isFull = group.currentMembers >= group.maxMembers
+  const fillPercent = (group.currentMembers / group.maxMembers) * 100
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKey)
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = ''
+    }
+  }, [onClose])
+
+  const handleJoin = () => {
+    onJoin(group.id)
+    onClose()
+  }
+
+  const shortAddress = (addr: string) => `${addr.slice(0, 8)}...${addr.slice(-4)}`
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative bg-white rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+        {/* Header */}
+        <div className="sticky top-0 bg-white border-b border-gray-100 px-6 py-4 flex items-start justify-between z-10 rounded-t-2xl">
+          <div className="flex-1 min-w-0 pr-4">
+            <div className="flex flex-wrap items-center gap-2 mb-1">
+              <h2 id="modal-title" className="text-xl font-bold text-gray-900 truncate">
+                {group.name}
+              </h2>
+              <span className={`px-2.5 py-0.5 rounded-full text-xs font-semibold border ${statusColors[group.status]}`}>
+                {group.status.charAt(0).toUpperCase() + group.status.slice(1)}
+              </span>
+            </div>
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {group.tags.map(tag => (
+                <span key={tag} className={`px-2 py-0.5 rounded text-xs font-medium ${tagColors[tag] ?? 'bg-gray-100 text-gray-600'}`}>
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="flex-shrink-0 p-2 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+            aria-label="Close modal"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="px-6 py-5 space-y-6">
+          {/* Description */}
+          <p className="text-gray-600 leading-relaxed">{group.description}</p>
+
+          {/* Key Stats Grid */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <div className="bg-blue-50 rounded-xl p-3 text-center">
+              <p className="text-xs text-blue-600 font-medium uppercase tracking-wide mb-1">Contribution</p>
+              <p className="text-lg font-bold text-blue-700">${group.contributionAmount}</p>
+              <p className="text-xs text-blue-500">{group.frequency}</p>
+            </div>
+            <div className="bg-purple-50 rounded-xl p-3 text-center">
+              <p className="text-xs text-purple-600 font-medium uppercase tracking-wide mb-1">Duration</p>
+              <p className="text-lg font-bold text-purple-700">{group.duration}</p>
+              <p className="text-xs text-purple-500">cycles</p>
+            </div>
+            <div className="bg-green-50 rounded-xl p-3 text-center">
+              <p className="text-xs text-green-600 font-medium uppercase tracking-wide mb-1">Total Raised</p>
+              <p className="text-lg font-bold text-green-700">${group.totalRaised.toLocaleString()}</p>
+              <p className="text-xs text-green-500">all time</p>
+            </div>
+            <div className="bg-orange-50 rounded-xl p-3 text-center">
+              <p className="text-xs text-orange-600 font-medium uppercase tracking-wide mb-1">Cycle Length</p>
+              <p className="text-lg font-bold text-orange-700">{group.cycleLength}</p>
+              <p className="text-xs text-orange-500">days</p>
+            </div>
+          </div>
+
+          {/* Member Progress */}
+          <div>
+            <div className="flex justify-between items-center mb-2">
+              <span className="text-sm font-semibold text-gray-700">Members</span>
+              <span className={`text-sm font-bold ${isFull ? 'text-red-600' : 'text-gray-900'}`}>
+                {group.currentMembers} / {group.maxMembers}
+                {isFull && <span className="ml-1 text-xs font-semibold text-red-500">(Full)</span>}
+              </span>
+            </div>
+            <div className="w-full bg-gray-200 rounded-full h-3 overflow-hidden">
+              <div
+                className={`h-3 rounded-full transition-all duration-500 ${isFull ? 'bg-red-500' : fillPercent >= 80 ? 'bg-orange-500' : 'bg-blue-600'}`}
+                style={{ width: `${fillPercent}%` }}
+              />
+            </div>
+            <p className="mt-1 text-xs text-gray-500">
+              {isFull ? 'Group is full' : `${group.maxMembers - group.currentMembers} spot${group.maxMembers - group.currentMembers !== 1 ? 's' : ''} remaining`}
+            </p>
+          </div>
+
+          {/* Creator Info */}
+          <div className="bg-gray-50 rounded-xl p-4">
+            <h3 className="text-sm font-semibold text-gray-700 mb-3">Creator</h3>
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white font-bold text-sm flex-shrink-0">
+                {group.creator.slice(0, 2).toUpperCase()}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-mono text-gray-700 truncate">{shortAddress(group.creator)}</p>
+                <div className="flex items-center gap-3 mt-1 flex-wrap">
+                  <StarRating value={group.creatorReputation} />
+                  <span className="text-xs text-gray-500">
+                    {group.creatorGroupsCount} group{group.creatorGroupsCount !== 1 ? 's' : ''} created
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Group Statistics */}
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700 mb-3">Group Statistics</h3>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex items-center gap-3 bg-white border border-gray-200 rounded-lg p-3">
+                <div className="w-8 h-8 rounded-lg bg-green-100 flex items-center justify-center flex-shrink-0">
+                  <svg className="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0" />
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-xs text-gray-500">Active Members</p>
+                  <p className="text-sm font-bold text-gray-900">{group.currentMembers}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 bg-white border border-gray-200 rounded-lg p-3">
+                <div className="w-8 h-8 rounded-lg bg-blue-100 flex items-center justify-center flex-shrink-0">
+                  <svg className="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-xs text-gray-500">Total Contributions</p>
+                  <p className="text-sm font-bold text-gray-900">${group.totalContributions.toLocaleString()}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 bg-white border border-gray-200 rounded-lg p-3">
+                <div className="w-8 h-8 rounded-lg bg-purple-100 flex items-center justify-center flex-shrink-0">
+                  <svg className="w-4 h-4 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-xs text-gray-500">Next Payout</p>
+                  <p className="text-sm font-bold text-gray-900">{group.nextPayoutDate}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 bg-white border border-gray-200 rounded-lg p-3">
+                <div className="w-8 h-8 rounded-lg bg-yellow-100 flex items-center justify-center flex-shrink-0">
+                  <svg className="w-4 h-4 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
+                  </svg>
+                </div>
+                <div>
+                  <p className="text-xs text-gray-500">Popularity</p>
+                  <p className="text-sm font-bold text-gray-900">{group.popularity}/100</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex gap-3 pt-2">
+            {group.isJoined ? (
+              <div className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl bg-green-50 border border-green-200 text-green-700 font-semibold">
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+                Joined
+              </div>
+            ) : (
+              <button
+                onClick={handleJoin}
+                disabled={isFull || group.status !== 'active'}
+                className="flex-1 py-3 rounded-xl bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-sm hover:shadow-md"
+              >
+                {isFull ? 'Group Full' : group.status !== 'active' ? 'Not Accepting Members' : 'Join Group'}
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="px-6 py-3 rounded-xl border border-gray-300 text-gray-700 font-semibold hover:bg-gray-50 transition-colors"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useExplore.ts
+++ b/frontend/src/hooks/useExplore.ts
@@ -1,0 +1,537 @@
+import { useState, useMemo } from 'react'
+import { Group } from '@/types'
+
+export interface ExploreGroup extends Group {
+  tags: string[]
+  popularity: number
+  creatorReputation: number
+  creatorGroupsCount: number
+  totalRaised: number
+  isJoined: boolean
+}
+
+export interface ExploreFilters {
+  search: string
+  minAmount: number | ''
+  maxAmount: number | ''
+  minMembers: number | ''
+  maxMembers: number | ''
+  minDuration: number | ''
+  maxDuration: number | ''
+  status: 'all' | 'active' | 'completed' | 'paused'
+  tags: string[]
+  frequency: 'all' | 'weekly' | 'monthly'
+}
+
+export type ExploreSortField = 'popularity' | 'createdAt' | 'members' | 'amount' | 'totalRaised'
+
+export interface ExploreSort {
+  field: ExploreSortField
+  direction: 'asc' | 'desc'
+}
+
+const ITEMS_PER_PAGE = 9
+
+export const ALL_TAGS = ['savings', 'housing', 'education', 'emergency', 'business', 'vacation', 'family', 'community']
+
+const defaultFilters: ExploreFilters = {
+  search: '',
+  minAmount: '',
+  maxAmount: '',
+  minMembers: '',
+  maxMembers: '',
+  minDuration: '',
+  maxDuration: '',
+  status: 'all',
+  tags: [],
+  frequency: 'all',
+}
+
+const MOCK_GROUPS: ExploreGroup[] = [
+  {
+    id: 'g1',
+    name: 'Monthly Savers Circle',
+    description: 'A community of dedicated savers working together toward financial freedom. We contribute monthly and rotate payouts fairly among trusted members.',
+    creator: 'GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5TO85CAJTL73B57GNTV5M',
+    cycleLength: 30,
+    contributionAmount: 100,
+    maxMembers: 10,
+    currentMembers: 8,
+    totalContributions: 4800,
+    status: 'active',
+    createdAt: '2024-01-15',
+    nextPayoutDate: '2024-03-01',
+    frequency: 'monthly',
+    duration: 10,
+    tags: ['savings', 'community'],
+    popularity: 92,
+    creatorReputation: 4.8,
+    creatorGroupsCount: 3,
+    totalRaised: 9600,
+    isJoined: false,
+  },
+  {
+    id: 'g2',
+    name: 'Housing Down Payment Fund',
+    description: 'Helping members save for their first home. High commitment group with rigorous screening to ensure all members meet contribution deadlines.',
+    creator: 'GBRP7XKJMZYVDCQFNHW2NQ3BPLT4UXREA6FQHZDK8CM5YN9V3SN2Q',
+    cycleLength: 30,
+    contributionAmount: 500,
+    maxMembers: 8,
+    currentMembers: 6,
+    totalContributions: 18000,
+    status: 'active',
+    createdAt: '2023-11-01',
+    nextPayoutDate: '2024-02-28',
+    frequency: 'monthly',
+    duration: 8,
+    tags: ['housing', 'savings'],
+    popularity: 78,
+    creatorReputation: 4.9,
+    creatorGroupsCount: 5,
+    totalRaised: 24000,
+    isJoined: false,
+  },
+  {
+    id: 'g3',
+    name: 'College Tuition Savers',
+    description: 'Parents and students pooling resources for higher education expenses. Flexible contribution schedule with monthly payouts.',
+    creator: 'GCLT9ADKPVMRWXUQBTHYZFJ6NK2SE8OCIG5LQRMBWP4A3HVD7YK7R',
+    cycleLength: 30,
+    contributionAmount: 200,
+    maxMembers: 12,
+    currentMembers: 9,
+    totalContributions: 10800,
+    status: 'active',
+    createdAt: '2024-01-20',
+    nextPayoutDate: '2024-03-15',
+    frequency: 'monthly',
+    duration: 12,
+    tags: ['education', 'family'],
+    popularity: 71,
+    creatorReputation: 4.5,
+    creatorGroupsCount: 2,
+    totalRaised: 21600,
+    isJoined: false,
+  },
+  {
+    id: 'g4',
+    name: 'Weekly Emergency Stash',
+    description: 'Build your emergency fund quickly with weekly micro-contributions. Perfect for anyone starting their financial safety net.',
+    creator: 'GDMN3PVKQRXZTJWYHIBOALSUF5EC4D8GNLJ2QOAM9T7BCRK6WF9T',
+    cycleLength: 7,
+    contributionAmount: 50,
+    maxMembers: 20,
+    currentMembers: 15,
+    totalContributions: 3000,
+    status: 'active',
+    createdAt: '2024-02-01',
+    nextPayoutDate: '2024-02-22',
+    frequency: 'weekly',
+    duration: 20,
+    tags: ['emergency', 'savings'],
+    popularity: 85,
+    creatorReputation: 4.2,
+    creatorGroupsCount: 4,
+    totalRaised: 4000,
+    isJoined: false,
+  },
+  {
+    id: 'g5',
+    name: 'Small Business Startup Pool',
+    description: 'Entrepreneurs supporting each other to launch small businesses. Larger contributions with quarterly payouts for business capital.',
+    creator: 'GBXR4TYWNZPQHKFD3CVMUASJ8LEB6OI5GMDQRTNKYV2CHX7P9M2C',
+    cycleLength: 90,
+    contributionAmount: 1000,
+    maxMembers: 5,
+    currentMembers: 4,
+    totalContributions: 16000,
+    status: 'active',
+    createdAt: '2023-10-01',
+    nextPayoutDate: '2024-04-01',
+    frequency: 'monthly',
+    duration: 5,
+    tags: ['business', 'savings'],
+    popularity: 63,
+    creatorReputation: 4.7,
+    creatorGroupsCount: 1,
+    totalRaised: 20000,
+    isJoined: false,
+  },
+  {
+    id: 'g6',
+    name: 'Summer Vacation Fund',
+    description: 'Travel together or individually with funds from this vacation savings group. Monthly contributions for a summer payout.',
+    creator: 'GDYH5RFPKBJNMQVXLW3OAZUTC9SED2I7GHCQR4MKY8VBNO6P1B',
+    cycleLength: 30,
+    contributionAmount: 150,
+    maxMembers: 8,
+    currentMembers: 5,
+    totalContributions: 2250,
+    status: 'active',
+    createdAt: '2024-01-10',
+    nextPayoutDate: '2024-06-01',
+    frequency: 'monthly',
+    duration: 8,
+    tags: ['vacation', 'savings'],
+    popularity: 74,
+    creatorReputation: 4.3,
+    creatorGroupsCount: 2,
+    totalRaised: 3600,
+    isJoined: false,
+  },
+  {
+    id: 'g7',
+    name: 'Community Growth Circle',
+    description: 'A tight-knit community group focused on collective wealth building. All members are vetted and active contributors.',
+    creator: 'GCNQ8LTYVFPKBJEM6DRAXUS3WZI5OHG9NLQCM2RBWP7K4V0D',
+    cycleLength: 30,
+    contributionAmount: 75,
+    maxMembers: 15,
+    currentMembers: 12,
+    totalContributions: 5400,
+    status: 'active',
+    createdAt: '2023-12-01',
+    nextPayoutDate: '2024-03-01',
+    frequency: 'monthly',
+    duration: 15,
+    tags: ['community', 'savings'],
+    popularity: 88,
+    creatorReputation: 4.6,
+    creatorGroupsCount: 6,
+    totalRaised: 6750,
+    isJoined: false,
+  },
+  {
+    id: 'g8',
+    name: 'Rent Assistance Network',
+    description: "Helping renters build stability by saving for deposits and first month's rent. Bi-weekly contributions with monthly payouts.",
+    creator: 'GBMK6QZYDVFPNJRXWCATO4LUH2SE8IB7GQMO3KYTCNXPVR5S8E',
+    cycleLength: 30,
+    contributionAmount: 250,
+    maxMembers: 10,
+    currentMembers: 10,
+    totalContributions: 12500,
+    status: 'active',
+    createdAt: '2023-09-01',
+    nextPayoutDate: '2024-02-15',
+    frequency: 'monthly',
+    duration: 10,
+    tags: ['housing', 'community'],
+    popularity: 95,
+    creatorReputation: 5.0,
+    creatorGroupsCount: 8,
+    totalRaised: 25000,
+    isJoined: false,
+  },
+  {
+    id: 'g9',
+    name: 'Weekly Micro Savers',
+    description: 'Low barrier entry for anyone wanting to start saving. Just $25 weekly to build consistent savings habits in a supportive community.',
+    creator: 'GDTV2NKPQXRYBWHZOFASM6JEU3DL9IGC4NQMBT5YRVCKH7P3F',
+    cycleLength: 7,
+    contributionAmount: 25,
+    maxMembers: 20,
+    currentMembers: 18,
+    totalContributions: 2250,
+    status: 'active',
+    createdAt: '2024-01-05',
+    nextPayoutDate: '2024-02-19',
+    frequency: 'weekly',
+    duration: 20,
+    tags: ['savings', 'community'],
+    popularity: 90,
+    creatorReputation: 4.4,
+    creatorGroupsCount: 3,
+    totalRaised: 2500,
+    isJoined: false,
+  },
+  {
+    id: 'g10',
+    name: 'Education Scholarship Pool',
+    description: 'Professionals and parents funding certification courses and degree programs. Three-month cycles with substantial payouts.',
+    creator: 'GCXP3MRTZKVYSQNJDWBFHAI4OLE6UG8QCFM2BYPT9VRDKX5J6G',
+    cycleLength: 90,
+    contributionAmount: 300,
+    maxMembers: 6,
+    currentMembers: 4,
+    totalContributions: 7200,
+    status: 'active',
+    createdAt: '2023-12-15',
+    nextPayoutDate: '2024-03-15',
+    frequency: 'monthly',
+    duration: 6,
+    tags: ['education', 'savings'],
+    popularity: 58,
+    creatorReputation: 4.7,
+    creatorGroupsCount: 2,
+    totalRaised: 10800,
+    isJoined: false,
+  },
+  {
+    id: 'g11',
+    name: 'Family Emergency Fund',
+    description: 'Families coming together to build emergency safety nets. Monthly contributions with priority payouts for urgent needs.',
+    creator: 'GBLM9XRPKVFTNWCQYH5AJZUE3BS7OID6GNQMLT4RBWCPX2T5H',
+    cycleLength: 30,
+    contributionAmount: 125,
+    maxMembers: 8,
+    currentMembers: 7,
+    totalContributions: 3500,
+    status: 'active',
+    createdAt: '2024-01-25',
+    nextPayoutDate: '2024-03-25',
+    frequency: 'monthly',
+    duration: 8,
+    tags: ['emergency', 'family'],
+    popularity: 69,
+    creatorReputation: 4.5,
+    creatorGroupsCount: 1,
+    totalRaised: 4000,
+    isJoined: false,
+  },
+  {
+    id: 'g12',
+    name: 'Digital Nomad Travel Fund',
+    description: 'Remote workers pooling funds for travel and coworking. Quarterly payouts to fund adventure and exploration worldwide.',
+    creator: 'GDKN4RTZWYVSQHPJXCFBAMO6LUI3EG5DCNQMLT8RBWKPX9B8I',
+    cycleLength: 90,
+    contributionAmount: 200,
+    maxMembers: 10,
+    currentMembers: 6,
+    totalContributions: 4800,
+    status: 'active',
+    createdAt: '2024-01-01',
+    nextPayoutDate: '2024-04-01',
+    frequency: 'monthly',
+    duration: 10,
+    tags: ['vacation', 'community'],
+    popularity: 76,
+    creatorReputation: 4.1,
+    creatorGroupsCount: 2,
+    totalRaised: 8000,
+    isJoined: false,
+  },
+  {
+    id: 'g13',
+    name: 'Freelancer Business Capital',
+    description: 'Freelancers and solopreneurs funding equipment, software, and marketing. Bi-monthly payouts to support business growth.',
+    creator: 'GCZQ7PVKNYFSRXWCJTOAL5UH3BE8IG6DQMO4KYTCNXPVR2S9J',
+    cycleLength: 60,
+    contributionAmount: 400,
+    maxMembers: 6,
+    currentMembers: 5,
+    totalContributions: 8000,
+    status: 'active',
+    createdAt: '2023-11-15',
+    nextPayoutDate: '2024-03-15',
+    frequency: 'monthly',
+    duration: 6,
+    tags: ['business', 'savings'],
+    popularity: 61,
+    creatorReputation: 4.6,
+    creatorGroupsCount: 3,
+    totalRaised: 9600,
+    isJoined: false,
+  },
+  {
+    id: 'g14',
+    name: 'Home Renovation Circle',
+    description: 'Homeowners saving for renovations and repairs. Monthly contributions with rotating payouts for major home improvement projects.',
+    creator: 'GBWT5NKPQXRZYWHFOAS4JEU6DL8IGCMNQMBT2YRVCKH9P7C9K',
+    cycleLength: 30,
+    contributionAmount: 350,
+    maxMembers: 8,
+    currentMembers: 8,
+    totalContributions: 14000,
+    status: 'completed',
+    createdAt: '2023-06-01',
+    nextPayoutDate: '2024-02-01',
+    frequency: 'monthly',
+    duration: 8,
+    tags: ['housing', 'savings'],
+    popularity: 82,
+    creatorReputation: 4.9,
+    creatorGroupsCount: 4,
+    totalRaised: 16800,
+    isJoined: false,
+  },
+  {
+    id: 'g15',
+    name: 'Student Loan Payoff Group',
+    description: 'Recent graduates helping each other pay off student loans faster. Bi-weekly contributions with monthly payouts to tackle debt.',
+    creator: 'GDFS8QMTVKYPRXWCJTO3LUH5BE9IG4DQMO6KYTCNXPVR7S2V7L',
+    cycleLength: 30,
+    contributionAmount: 175,
+    maxMembers: 12,
+    currentMembers: 9,
+    totalContributions: 9450,
+    status: 'active',
+    createdAt: '2024-01-30',
+    nextPayoutDate: '2024-03-30',
+    frequency: 'monthly',
+    duration: 12,
+    tags: ['education', 'savings'],
+    popularity: 73,
+    creatorReputation: 4.3,
+    creatorGroupsCount: 1,
+    totalRaised: 12600,
+    isJoined: false,
+  },
+  {
+    id: 'g16',
+    name: 'Neighborhood Watch Fund',
+    description: 'Community members saving for local security improvements and emergency preparedness. Low monthly contribution with collective impact.',
+    creator: 'GCMH2TRPKVFYNWCQZH5AJUE6BS8OID3GNQMLT7RBWCPX4T2A4M',
+    cycleLength: 30,
+    contributionAmount: 50,
+    maxMembers: 20,
+    currentMembers: 14,
+    totalContributions: 4200,
+    status: 'paused',
+    createdAt: '2023-10-15',
+    nextPayoutDate: '2024-04-15',
+    frequency: 'monthly',
+    duration: 20,
+    tags: ['community', 'emergency'],
+    popularity: 55,
+    creatorReputation: 3.9,
+    creatorGroupsCount: 1,
+    totalRaised: 6000,
+    isJoined: false,
+  },
+  {
+    id: 'g17',
+    name: 'Holiday Gift Savings',
+    description: 'Friends and family saving together for holiday gifts and celebrations. Small weekly amounts add up to meaningful holiday budgets.',
+    creator: 'GBYL6PTZWYVSQHNKXCFBAO4LUI5EG8DCNQMLT3RBWKPX6B1N',
+    cycleLength: 7,
+    contributionAmount: 40,
+    maxMembers: 15,
+    currentMembers: 11,
+    totalContributions: 2200,
+    status: 'active',
+    createdAt: '2024-01-08',
+    nextPayoutDate: '2024-12-01',
+    frequency: 'weekly',
+    duration: 15,
+    tags: ['family', 'savings'],
+    popularity: 80,
+    creatorReputation: 4.4,
+    creatorGroupsCount: 2,
+    totalRaised: 3000,
+    isJoined: false,
+  },
+  {
+    id: 'g18',
+    name: 'Professional Development Fund',
+    description: 'Career-focused individuals saving for conferences, certifications, and courses. Monthly payouts for professional growth opportunities.',
+    creator: 'GDMK3RTZVKYSQHPJXCFBAMO5LUI4EG7DCNQMLT9RBWKPX8B6P6O',
+    cycleLength: 30,
+    contributionAmount: 80,
+    maxMembers: 10,
+    currentMembers: 7,
+    totalContributions: 3360,
+    status: 'active',
+    createdAt: '2024-02-01',
+    nextPayoutDate: '2024-05-01',
+    frequency: 'monthly',
+    duration: 10,
+    tags: ['education', 'business'],
+    popularity: 66,
+    creatorReputation: 4.5,
+    creatorGroupsCount: 2,
+    totalRaised: 4800,
+    isJoined: false,
+  },
+]
+
+export function useExplore() {
+  const [filters, setFilters] = useState<ExploreFilters>(defaultFilters)
+  const [sort, setSort] = useState<ExploreSort>({ field: 'popularity', direction: 'desc' })
+  const [page, setPage] = useState(1)
+  const [joinedIds, setJoinedIds] = useState<Set<string>>(new Set())
+
+  const filteredGroups = useMemo(() => {
+    let result = MOCK_GROUPS.map(g => ({ ...g, isJoined: joinedIds.has(g.id) }))
+
+    if (filters.search.trim()) {
+      const q = filters.search.toLowerCase()
+      result = result.filter(
+        g =>
+          g.name.toLowerCase().includes(q) ||
+          g.creator.toLowerCase().includes(q) ||
+          (g.description?.toLowerCase().includes(q) ?? false)
+      )
+    }
+
+    if (filters.minAmount !== '') result = result.filter(g => g.contributionAmount >= Number(filters.minAmount))
+    if (filters.maxAmount !== '') result = result.filter(g => g.contributionAmount <= Number(filters.maxAmount))
+    if (filters.minMembers !== '') result = result.filter(g => g.maxMembers >= Number(filters.minMembers))
+    if (filters.maxMembers !== '') result = result.filter(g => g.maxMembers <= Number(filters.maxMembers))
+    if (filters.minDuration !== '') result = result.filter(g => (g.duration ?? 0) >= Number(filters.minDuration))
+    if (filters.maxDuration !== '') result = result.filter(g => (g.duration ?? 0) <= Number(filters.maxDuration))
+
+    if (filters.status !== 'all') result = result.filter(g => g.status === filters.status)
+    if (filters.frequency !== 'all') result = result.filter(g => g.frequency === filters.frequency)
+    if (filters.tags.length > 0) result = result.filter(g => filters.tags.some(tag => g.tags.includes(tag)))
+
+    result.sort((a, b) => {
+      let aVal: number
+      let bVal: number
+      switch (sort.field) {
+        case 'popularity':
+          aVal = a.popularity; bVal = b.popularity; break
+        case 'createdAt':
+          aVal = new Date(a.createdAt).getTime(); bVal = new Date(b.createdAt).getTime(); break
+        case 'members':
+          aVal = a.currentMembers; bVal = b.currentMembers; break
+        case 'amount':
+          aVal = a.contributionAmount; bVal = b.contributionAmount; break
+        case 'totalRaised':
+          aVal = a.totalRaised; bVal = b.totalRaised; break
+        default:
+          aVal = a.popularity; bVal = b.popularity
+      }
+      return sort.direction === 'desc' ? bVal - aVal : aVal - bVal
+    })
+
+    return result
+  }, [filters, sort, joinedIds])
+
+  const totalPages = Math.max(1, Math.ceil(filteredGroups.length / ITEMS_PER_PAGE))
+
+  const paginatedGroups = useMemo(() => {
+    const start = (page - 1) * ITEMS_PER_PAGE
+    return filteredGroups.slice(start, start + ITEMS_PER_PAGE)
+  }, [filteredGroups, page])
+
+  const updateFilters = (updates: Partial<ExploreFilters>) => {
+    setFilters(prev => ({ ...prev, ...updates }))
+    setPage(1)
+  }
+
+  const resetFilters = () => {
+    setFilters(defaultFilters)
+    setPage(1)
+  }
+
+  const joinGroup = (groupId: string) => {
+    setJoinedIds(prev => new Set([...prev, groupId]))
+  }
+
+  return {
+    filteredGroups,
+    paginatedGroups,
+    filters,
+    updateFilters,
+    resetFilters,
+    sort,
+    setSort: (s: ExploreSort) => { setSort(s); setPage(1) },
+    page,
+    setPage,
+    totalPages,
+    totalCount: filteredGroups.length,
+    joinGroup,
+  }
+}

--- a/frontend/src/pages/Explore.tsx
+++ b/frontend/src/pages/Explore.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { GroupExplorer } from '@/components/GroupExplorer'
+
+export const Explore: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      {/* Page Header */}
+      <div className="bg-gradient-to-r from-blue-600 to-purple-600 rounded-2xl px-6 py-8 text-white shadow-lg">
+        <h2 className="text-3xl font-bold mb-2">Discover Groups</h2>
+        <p className="text-blue-100 text-base max-w-xl">
+          Browse public savings groups, filter by your preferences, and join a community working toward shared financial goals.
+        </p>
+        <div className="flex flex-wrap gap-4 mt-5 text-sm">
+          <div className="flex items-center gap-2 bg-white/20 rounded-lg px-3 py-2">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0" />
+            </svg>
+            <span>18 Public Groups</span>
+          </div>
+          <div className="flex items-center gap-2 bg-white/20 rounded-lg px-3 py-2">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span>$25 – $1,000/cycle</span>
+          </div>
+          <div className="flex items-center gap-2 bg-white/20 rounded-lg px-3 py-2">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+            </svg>
+            <span>8 Categories</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Explorer */}
+      <GroupExplorer />
+    </div>
+  )
+}


### PR DESCRIPTION
# Explore/Discovery Page Implementation

## Summary
- Adds a full-featured group discovery page with search, advanced filtering, sorting, and group preview modal
- Implements `useExplore` hook for stateful filtering, sorting, and pagination logic
- Covers all acceptance criteria: search, filter, sort, preview modal, join flow, creator reputation, group stats, tags, and pagination

## Changes
- Created `frontend/src/hooks/useExplore.ts` — hook with 18 mock groups, filter/sort/pagination state, and join tracking
- Created `frontend/src/components/GroupExplorer.tsx` — search bar, collapsible filter sidebar (desktop/mobile drawer), sort toolbar, responsive card grid, pagination
- Created `frontend/src/components/GroupPreviewModal.tsx` — full-detail modal with stats grid, creator reputation stars, member progress, join button
- Created `frontend/src/pages/Explore.tsx` — page wrapper with hero header
- Updated `frontend/src/App.tsx` — added `explore` view to nav and render logic

## Features
- Search by group name, creator address, or description
- Advanced filters: amount range, max members range, duration range, status, frequency, tags/categories
- Sort by popularity, creation date, member count, contribution amount, total raised (asc/desc toggle)
- Group preview modal with full details, creator reputation score, statistics, and join action
- Join group directly from listing with persistent joined state
- 8 category tags with color coding (savings, housing, education, emergency, business, vacation, family, community)
- Pagination — 9 results per page with smart ellipsis navigation
- Responsive: filter drawer on mobile, sidebar on desktop
- Empty state with clear-filters shortcut

## Screenshot
<img width="1366" height="768" alt="Screenshot (3578)" src="https://github.com/user-attachments/assets/ff42b3f2-18dd-4dea-b197-e5076ef8b384" />
<img width="1366" height="768" alt="Screenshot (3579)" src="https://github.com/user-attachments/assets/d9233c44-5b78-47cd-b42c-7cb5750062bb" />

Closes #32
