### PR TITLE
feat: polish analytics UI and implement Recharts with theme tokens (#54)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -106,7 +106,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1593,8 +1592,7 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
       "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai-subset": {
       "version": "1.3.6",
@@ -1696,7 +1694,6 @@
       "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1714,7 +1711,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1779,7 +1775,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2168,7 +2163,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2567,7 +2561,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2896,8 +2889,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -3384,7 +3376,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4586,7 +4577,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5299,7 +5289,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5542,7 +5531,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5555,7 +5543,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6480,7 +6467,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6621,7 +6607,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6759,7 +6744,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -6844,7 +6828,6 @@
       "integrity": "sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",

--- a/frontend/src/components/GroupAnalytics.tsx
+++ b/frontend/src/components/GroupAnalytics.tsx
@@ -3,6 +3,19 @@
 // Status: Placeholder
 
 import React from 'react'
+// TASK: IMPORTED RECHARTS COMPONENTS (#54)
+import { 
+  ResponsiveContainer, 
+  AreaChart, 
+  Area, 
+  BarChart, 
+  Bar, 
+  XAxis, 
+  YAxis, 
+  CartesianGrid, 
+  Tooltip, 
+  Legend 
+} from 'recharts'
 
 interface AnalyticsMetric {
   label: string
@@ -20,6 +33,23 @@ export const GroupAnalytics: React.FC = () => {
     { label: 'Active Members', value: '32', change: '+2', trend: 'up' },
     { label: 'Avg Cycle Time', value: '29 days', change: '-1 day', trend: 'down' },
     { label: 'Payouts Completed', value: '14', change: '+1', trend: 'up' },
+  ]
+
+  // TASK: ADDED DUMMY DATA FOR THE CHARTS TO RENDER (#54)
+  const trendData = [
+    { name: 'Jan', amount: 4000 },
+    { name: 'Feb', amount: 3000 },
+    { name: 'Mar', amount: 5000 },
+    { name: 'Apr', amount: 4500 },
+    { name: 'May', amount: 6000 },
+    { name: 'Jun', amount: 5500 },
+  ]
+
+  const timelineData = [
+    { name: 'Week 1', completed: 4, pending: 2 },
+    { name: 'Week 2', completed: 3, pending: 4 },
+    { name: 'Week 3', completed: 5, pending: 1 },
+    { name: 'Week 4', completed: 2, pending: 3 },
   ]
 
   return (
@@ -52,15 +82,58 @@ export const GroupAnalytics: React.FC = () => {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <div className="bg-white rounded-lg shadow p-6">
           <h3 className="text-xl font-bold mb-4">Contribution Trends</h3>
-          <div className="h-64 bg-gray-50 rounded flex items-center justify-center">
-            <p className="text-gray-500">Chart Placeholder (Recharts)</p>
+          {/* Note: I removed the flex justify-center classes from this specific div so Recharts can expand properly */}
+          <div className="h-64 bg-gray-50 rounded pt-4 pr-4">
+            {/* TASK: IMPLEMENTED AREA CHART WITH CSS VARIABLES AND TOOLTIP STYLING (#54) */}
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={trendData} margin={{ top: 0, right: 0, left: -20, bottom: 0 }}>
+                <defs>
+                  <linearGradient id="colorAmount" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="var(--chart-primary)" stopOpacity={0.8}/>
+                    <stop offset="95%" stopColor="var(--chart-primary)" stopOpacity={0}/>
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid-line)" vertical={false} />
+                <XAxis dataKey="name" tick={{ fill: '#64748b', fontSize: 12 }} axisLine={false} tickLine={false} dy={10} />
+                <YAxis tick={{ fill: '#64748b', fontSize: 12 }} axisLine={false} tickLine={false} />
+                <Tooltip 
+                  contentStyle={{ 
+                    backgroundColor: 'var(--chart-tooltip-bg)', 
+                    borderColor: 'var(--chart-tooltip-border)', 
+                    color: 'var(--chart-tooltip-text)',
+                    borderRadius: '8px' 
+                  }} 
+                />
+                <Area type="monotone" dataKey="amount" stroke="var(--chart-primary)" fillOpacity={1} fill="url(#colorAmount)" />
+              </AreaChart>
+            </ResponsiveContainer>
           </div>
         </div>
 
         <div className="bg-white rounded-lg shadow p-6">
           <h3 className="text-xl font-bold mb-4">Payout Timeline</h3>
-          <div className="h-64 bg-gray-50 rounded flex items-center justify-center">
-            <p className="text-gray-500">Timeline Placeholder</p>
+          {/* Note: Removed flex justify-center here as well so Recharts fills the container */}
+          <div className="h-64 bg-gray-50 rounded pt-4 pr-4">
+            {/* TASK: IMPLEMENTED BAR CHART WITH CSS VARIABLES, SPACING, AND LEGEND (#54) */}
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={timelineData} margin={{ top: 0, right: 0, left: -20, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid-line)" vertical={false} />
+                <XAxis dataKey="name" tick={{ fill: '#64748b', fontSize: 12 }} axisLine={false} tickLine={false} dy={10} />
+                <YAxis tick={{ fill: '#64748b', fontSize: 12 }} axisLine={false} tickLine={false} />
+                <Tooltip 
+                  cursor={{ fill: 'transparent' }}
+                  contentStyle={{ 
+                    backgroundColor: 'var(--chart-tooltip-bg)', 
+                    borderColor: 'var(--chart-tooltip-border)', 
+                    color: 'var(--chart-tooltip-text)',
+                    borderRadius: '8px' 
+                  }} 
+                />
+                <Legend wrapperStyle={{ paddingTop: '10px' }} iconType="circle" />
+                <Bar dataKey="completed" fill="var(--chart-primary)" radius={[4, 4, 0, 0]} name="Completed" />
+                <Bar dataKey="pending" fill="var(--chart-secondary)" radius={[4, 4, 0, 0]} name="Pending" />
+              </BarChart>
+            </ResponsiveContainer>
           </div>
         </div>
       </div>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -15,6 +15,27 @@
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* --- Issue #54: Chart Color Tokens & Tooltip Styling --- */
+  --chart-primary: #6366f1;   /* Indigo */
+  --chart-secondary: #8b5cf6; /* Violet */
+  --chart-tertiary: #ec4899;  /* Pink */
+  --chart-quaternary: #14b8a6; /* Teal */
+  
+  --chart-tooltip-bg: #ffffff;
+  --chart-tooltip-border: #e2e8f0;
+  --chart-tooltip-text: #1e293b;
+  --chart-grid-line: #f1f5f9;
+}
+
+/* Dark mode overrides for charts */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --chart-tooltip-bg: #1e293b;
+    --chart-tooltip-border: #334155;
+    --chart-tooltip-text: #f8fafc;
+    --chart-grid-line: #334155;
+  }
 }
 
 a {


### PR DESCRIPTION
Resolves #54

What I did:

Defined consistent chart color tokens in index.css for a unified theme.

Replaced the placeholder boxes in GroupAnalytics.tsx with actual recharts components (AreaChart and BarChart).

Polished the visual hierarchy, tooltips, and legend spacing to match the app's clean UI.

Added some dummy data so the charts render beautifully for review.

Let me know if you need me to adjust any of the colors or spacing!
<img width="1333" height="578" alt="AJO" src="https://github.com/user-attachments/assets/4e97aa28-442d-418a-a15e-080b03ffa0ef" />
