### PR TITLE
docs: add testnet deployment walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ cargo test
 stellar contract deploy --wasm target/wasm32-unknown-unknown/release/ajo.wasm
 ```
 
+### Testnet Deployment (recommended)
+
+Use the helper script to deploy the contract to Stellar testnet:
+
+```bash
+# From repo root
+scripts/deploy_testnet.sh
+```
+
+What it does:
+- Ensures Soroban CLI, Rust, and testnet network config exist
+- Generates a `deployer` identity (if missing) and prompts you to fund it via friendbot
+- Builds and optimizes the contract
+- Deploys to testnet and writes the contract ID to `contract-id.txt`
+- Prints next steps and an explorer link
+
+See the full walkthrough in `demo/demo-script.md`.
+
+**Troubleshooting**
+- If deployment fails with funding errors: fund the deployer shown in the script output via `https://friendbot.stellar.org?addr=<address>`, then re-run.
+- If `soroban` can't find `testnet`: the script re-adds it, or you can run  
+  `soroban network add --global testnet --rpc-url https://soroban-testnet.stellar.org:443 --network-passphrase "Test SDF Network ; September 2015"`.
+
 ### Backend API (Node.js/Express)
 
 ```bash

--- a/demo/demo-script.md
+++ b/demo/demo-script.md
@@ -1,0 +1,45 @@
+# Soroban Ajo — Testnet Deployment Walkthrough
+
+Step-by-step guide for deploying the Ajo contract to Stellar testnet using the provided helper script.
+
+## Prerequisites
+- Rust toolchain (`cargo`)
+- Soroban CLI: `cargo install --locked soroban-cli --features opt`
+- Fundable testnet account (friendbot)
+
+## Steps
+1. From the repo root, run:
+   ```bash
+   scripts/deploy_testnet.sh
+   ```
+2. When prompted, fund the generated `deployer` address via friendbot:
+   ```
+   https://friendbot.stellar.org?addr=<deployer_address>
+   ```
+3. Let the script:
+   - configure the `testnet` network (if missing)
+   - build and optimize the contract
+   - deploy to testnet
+4. Note the outputs:
+   - `contract-id.txt` contains the deployed contract ID
+   - Explorer link printed at the end: `https://stellar.expert/explorer/testnet/contract/<contract_id>`
+
+## Quick invokes
+After deployment, you can interact with the contract. Examples:
+```bash
+CONTRACT_ID=$(cat contract-id.txt)
+
+# Create test users
+soroban keys generate alice --network testnet
+soroban keys generate bob --network testnet
+
+# Inspect contract
+soroban contract inspect --id "$CONTRACT_ID" --network testnet
+```
+
+## Troubleshooting
+- **Funding error**: Re-run friendbot for the `deployer` address, wait a few seconds, then re-run the script.
+- **Missing testnet**: Add it manually  
+  `soroban network add --global testnet --rpc-url https://soroban-testnet.stellar.org:443 --network-passphrase "Test SDF Network ; September 2015"`
+- **Build issues**: Ensure Rust target is installed  
+  `rustup target add wasm32-unknown-unknown`


### PR DESCRIPTION
## Summary
- add README testnet deployment section referencing the helper script
- include a standalone demo script walkthrough with friendbot and invoke tips

## Rationale
- README lacked step-by-step testnet deployment guidance (issue #10)

## Changes
- README: new Testnet Deployment section + troubleshooting
- demo/demo-script.md: detailed walkthrough, funding instructions, quick invokes

## Tests
- not run (docs-only)

Fixes #10