### PR TITLE
feat: Add multi-language support (i18n) - Issue #245

### DIFF
--- a/frontend/docs/I18N_GUIDE.md
+++ b/frontend/docs/I18N_GUIDE.md
@@ -1,0 +1,224 @@
+# Multi-language Support (i18n) Implementation
+
+## Overview
+The Ajo app now supports 5 languages with full internationalization using `next-intl`.
+
+## Supported Languages
+- **English (en)** - Default
+- **Spanish (es)** - Español
+- **French (fr)** - Français
+- **Portuguese (pt)** - Português
+- **Swahili (sw)** - Kiswahili
+
+## Architecture
+
+### File Structure
+```
+frontend/src/
+├── i18n.ts                          # i18n configuration
+├── middleware.ts                     # Locale routing middleware
+├── locales/                         # Translation files
+│   ├── en.json
+│   ├── es.json
+│   ├── fr.json
+│   ├── pt.json
+│   └── sw.json
+├── app/
+│   └── [locale]/                    # Locale-based routing
+│       ├── layout.tsx               # Locale-aware layout
+│       └── page.tsx                 # Translated pages
+├── components/
+│   └── LanguageSelector.tsx         # Language switcher
+├── hooks/
+│   └── useTranslation.ts            # Translation hook
+└── utils/i18n/
+    └── formatters.ts                # Locale-aware formatters
+```
+
+### URL Structure
+All routes are prefixed with locale:
+- `/en/dashboard` - English
+- `/es/dashboard` - Spanish
+- `/fr/dashboard` - French
+- `/pt/dashboard` - Portuguese
+- `/sw/dashboard` - Swahili
+
+## Usage
+
+### In Components
+```tsx
+import { useTranslations } from 'next-intl';
+
+export default function MyComponent() {
+  const t = useTranslations('namespace');
+  
+  return <h1>{t('key')}</h1>;
+}
+```
+
+### With Custom Hook
+```tsx
+import { useTranslation } from '@/hooks/useTranslation';
+
+export default function MyComponent() {
+  const { t, formatCurrency, formatDate } = useTranslation('namespace');
+  
+  return (
+    <div>
+      <p>{t('label')}</p>
+      <p>{formatCurrency(100)}</p>
+      <p>{formatDate(new Date())}</p>
+    </div>
+  );
+}
+```
+
+### Formatting
+
+#### Currency
+```tsx
+const { formatCurrency } = useTranslation();
+formatCurrency(100.5) // "100.50 XLM"
+```
+
+#### Dates
+```tsx
+const { formatDate } = useTranslation();
+formatDate(new Date()) // Locale-aware date format
+```
+
+#### Relative Time
+```tsx
+const { formatRelativeTime } = useTranslation();
+formatRelativeTime(new Date(Date.now() - 3600000)) // "1 hour ago"
+```
+
+## Translation Keys Organization
+
+### Structure
+```json
+{
+  "common": {
+    "appName": "Ajo",
+    "loading": "Loading...",
+    "error": "Error"
+  },
+  "nav": {
+    "home": "Home",
+    "dashboard": "Dashboard"
+  },
+  "group": {
+    "create": "Create Group",
+    "join": "Join Group"
+  }
+}
+```
+
+### Namespaces
+- `common` - Shared UI elements
+- `nav` - Navigation labels
+- `home` - Home page content
+- `wallet` - Wallet-related text
+- `group` - Group management
+- `groupForm` - Group creation form
+- `contribution` - Contribution actions
+- `transaction` - Transaction history
+- `profile` - User profile
+- `analytics` - Analytics page
+- `language` - Language names
+- `errors` - Error messages
+- `time` - Time-related labels
+
+## Language Selector
+
+The language selector is available in:
+- Top navigation bar (desktop)
+- Mobile menu
+- Profile settings
+
+Language preference is stored in `localStorage` and persists across sessions.
+
+## Adding New Languages
+
+1. Create translation file: `frontend/src/locales/[code].json`
+2. Add locale to `frontend/src/i18n.ts`:
+   ```ts
+   export const locales = ['en', 'es', 'fr', 'pt', 'sw', 'ar'] as const;
+   ```
+3. Add language name to all locale files:
+   ```json
+   {
+     "language": {
+       "ar": "العربية"
+     }
+   }
+   ```
+
+## RTL Support (Future)
+
+For RTL languages like Arabic:
+1. Add `dir` attribute to `<html>` tag based on locale
+2. Update Tailwind config for RTL variants
+3. Test layout with RTL-specific styles
+
+## Best Practices
+
+### DO
+✅ Use translation keys for all user-facing text
+✅ Organize keys by feature/namespace
+✅ Use locale-aware formatters for dates/currency
+✅ Test all languages before deployment
+✅ Keep translation files in sync
+
+### DON'T
+❌ Hardcode text in components
+❌ Mix languages in translation files
+❌ Use generic keys like `text1`, `text2`
+❌ Forget to translate error messages
+❌ Assume date/number formats
+
+## Testing
+
+### Manual Testing
+1. Switch language using selector
+2. Verify all text is translated
+3. Check date/currency formatting
+4. Test navigation with locale URLs
+5. Verify localStorage persistence
+
+### Automated Testing
+```bash
+# Type check translations
+npm run type-check
+
+# Build to verify all locales
+npm run build
+```
+
+## Performance
+
+- Translation files are code-split by locale
+- Only active locale is loaded
+- Middleware handles locale routing efficiently
+- No runtime overhead for unused languages
+
+## Maintenance
+
+### Updating Translations
+1. Edit JSON files in `frontend/src/locales/`
+2. Keep all locale files in sync
+3. Use consistent key naming
+4. Document context for translators
+
+### Translation Workflow
+1. Developer adds English keys
+2. Export keys for translation
+3. Translators provide translations
+4. Import translations back to JSON files
+5. Test and deploy
+
+## Resources
+
+- [next-intl Documentation](https://next-intl-docs.vercel.app/)
+- [Intl API Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)
+- [CLDR Locale Data](http://cldr.unicode.org/)

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -147,6 +147,8 @@ const withPWA = require('next-pwa')({
   },
 })
 
+const withNextIntl = require('next-intl/plugin')('./src/i18n.ts');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -167,4 +169,4 @@ const nextConfig = {
   },
 }
 
-module.exports = withPWA(nextConfig)
+module.exports = withPWA(withNextIntl(nextConfig))

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "framer-motion": "^11.18.2",
     "lucide-react": "^0.575.0",
     "next": "^14.1.0",
+    "next-intl": "^4.8.3",
     "next-themes": "^0.4.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/app/[locale]/analytics/page.tsx
+++ b/frontend/src/app/[locale]/analytics/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+import { useEffect, useState } from "react";
+
+interface Stats {
+  totalEvents: number;
+  eventsByType: { type: string; count: number }[];
+  eventsByCategory: { category: string; count: number }[];
+  errorsBySeverity: { severity: string; count: number }[];
+  recentEvents: any[];
+}
+
+export default function AnalyticsDashboard() {
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/analytics/stats")
+      .then((r) => r.json())
+      .then((data) => {
+        setStats(data);
+        setLoading(false);
+      })
+      .catch(() => {
+        setError("Failed to load analytics data");
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) return (
+    <div className="min-h-screen bg-[#0a0e27] text-green-400 font-mono flex items-center justify-center">
+      <p className="animate-pulse">Loading analytics...</p>
+    </div>
+  );
+
+  if (error) return (
+    <div className="min-h-screen bg-[#0a0e27] text-red-400 font-mono flex items-center justify-center">
+      <p>{error}</p>
+    </div>
+  );
+
+  return (
+    <main className="min-h-screen bg-[#0a0e27] text-green-400 font-mono p-6">
+      <div className="max-w-5xl mx-auto">
+        {/* Header */}
+        <div className="mb-6 border-b border-green-500/30 pb-4">
+          <h1 className="text-xl font-bold tracking-widest">◆ ANALYTICS DASHBOARD</h1>
+          <p className="text-green-600 text-xs mt-1">Real-time metrics and event tracking</p>
+        </div>
+
+        {/* Summary Cards */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+          {[
+            { label: "TOTAL EVENTS", value: stats?.totalEvents || 0 },
+            { label: "EVENT TYPES", value: stats?.eventsByType?.length || 0 },
+            { label: "CATEGORIES", value: stats?.eventsByCategory?.length || 0 },
+            { label: "ERRORS", value: stats?.errorsBySeverity?.reduce((s, e) => s + Number(e.count), 0) || 0 },
+          ].map(({ label, value }) => (
+            <div key={label} className="border border-green-500/30 rounded p-4">
+              <p className="text-green-600 text-xs mb-1">{label}</p>
+              <p className="text-green-400 text-2xl font-bold">{value}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+          {/* Events by Type */}
+          <div className="border border-green-500/30 rounded p-4">
+            <h2 className="text-green-400 text-sm mb-3">[ EVENTS BY TYPE ]</h2>
+            {stats?.eventsByType?.length === 0 ? (
+              <p className="text-green-700 text-sm">No data yet</p>
+            ) : (
+              stats?.eventsByType?.map((e) => (
+                <div key={e.type} className="flex justify-between py-1 border-b border-green-500/10">
+                  <span className="text-green-300 text-sm">{e.type}</span>
+                  <span className="text-green-500 text-sm">{e.count}</span>
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* Events by Category */}
+          <div className="border border-green-500/30 rounded p-4">
+            <h2 className="text-green-400 text-sm mb-3">[ EVENTS BY CATEGORY ]</h2>
+            {stats?.eventsByCategory?.length === 0 ? (
+              <p className="text-green-700 text-sm">No data yet</p>
+            ) : (
+              stats?.eventsByCategory?.map((e) => (
+                <div key={e.category} className="flex justify-between py-1 border-b border-green-500/10">
+                  <span className="text-green-300 text-sm">{e.category}</span>
+                  <span className="text-green-500 text-sm">{e.count}</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Errors by Severity */}
+        <div className="border border-green-500/30 rounded p-4 mb-6">
+          <h2 className="text-green-400 text-sm mb-3">[ ERRORS BY SEVERITY ]</h2>
+          <div className="grid grid-cols-4 gap-3">
+            {["low", "medium", "high", "critical"].map((sev) => {
+              const found = stats?.errorsBySeverity?.find((e) => e.severity === sev);
+              const colors: Record<string, string> = {
+                low: "text-green-400",
+                medium: "text-yellow-400",
+                high: "text-orange-400",
+                critical: "text-red-400",
+              };
+              return (
+                <div key={sev} className="border border-green-500/30 rounded p-3 text-center">
+                  <p className={`text-xs mb-1 ${colors[sev]}`}>{sev.toUpperCase()}</p>
+                  <p className={`text-xl font-bold ${colors[sev]}`}>{found?.count || 0}</p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Recent Events */}
+        <div className="border border-green-500/30 rounded p-4">
+          <h2 className="text-green-400 text-sm mb-3">[ RECENT EVENTS ]</h2>
+          {stats?.recentEvents?.length === 0 ? (
+            <p className="text-green-700 text-sm">No events yet</p>
+          ) : (
+            <div className="space-y-2 max-h-64 overflow-y-auto">
+              {stats?.recentEvents?.map((e, i) => (
+                <div key={i} className="flex justify-between text-xs py-1 border-b border-green-500/10">
+                  <span className="text-green-500">{e.type}</span>
+                  <span className="text-green-300">{e.category} / {e.action}</span>
+                  <span className="text-green-700">{new Date(e.timestamp).toLocaleTimeString()}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/[locale]/community/page.tsx
+++ b/frontend/src/app/[locale]/community/page.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { CommunityLinks } from '@/components/CommunityLinks'
+
+export default function CommunityPage() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <div className="text-center mb-16">
+        <h1 className="text-4xl font-bold text-gray-900 mb-4">Community Hub</h1>
+        <p className="text-xl text-gray-600 max-w-2xl mx-auto">
+          Join the conversation, shape the future of Soroban Ajo, and connect with other members.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-16">
+        {/* Governance Forum Card */}
+        <div className="bg-white p-8 rounded-xl shadow-sm border border-gray-100 flex flex-col items-start">
+          <div className="h-12 w-12 bg-blue-100 rounded-lg flex items-center justify-center mb-6 text-blue-600">
+             <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 8h2a2 2 0 012 2v6a2 2 0 01-2 2h-2v4l-4-4H9a1.994 1.994 0 01-1.414-.586m0 0L11 14h4a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2v4l.586-.586z" /></svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-3">Governance Forum</h2>
+          <p className="text-gray-600 mb-6 flex-grow">
+            Participate in decision-making processes, propose new features, and vote on protocol upgrades.
+          </p>
+          <a href="#" className="inline-flex items-center text-blue-600 font-semibold hover:text-blue-700 mt-auto">
+            Go to Forum <span className="ml-2">→</span>
+          </a>
+        </div>
+
+        {/* Discord Community Card */}
+        <div className="bg-white p-8 rounded-xl shadow-sm border border-gray-100 flex flex-col items-start">
+           <div className="h-12 w-12 bg-indigo-100 rounded-lg flex items-center justify-center mb-6 text-indigo-600">
+             <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03z"/></svg>
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900 mb-3">Discord Server</h2>
+          <p className="text-gray-600 mb-6 flex-grow">
+            Chat with developers, get support, and hang out with the community in real-time.
+          </p>
+          <a href="#" className="inline-flex items-center text-indigo-600 font-semibold hover:text-indigo-700 mt-auto">
+            Join Server <span className="ml-2">→</span>
+          </a>
+        </div>
+      </div>
+
+      <div className="bg-gray-50 rounded-2xl p-8 md:p-12 text-center">
+        <h2 className="text-3xl font-bold text-gray-900 mb-6">Connect on Social Media</h2>
+        <div className="flex justify-center">
+          <CommunityLinks />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/[locale]/dashboard/Dashboard.tsx
+++ b/frontend/src/app/[locale]/dashboard/Dashboard.tsx
@@ -1,0 +1,251 @@
+'use client'
+
+// Issue #213: Implement User Groups Dashboard
+// Changes from original:
+//   1. Import UserGroupsDashboard
+//   2. Pull createdGroups, joinedGroups, stats, userAddress from useDashboard
+//   3. Render <UserGroupsDashboard> between the page header and the controls bar
+
+import React from 'react'
+import { useRouter } from 'next/navigation'
+import { useDashboard } from '@/hooks/useDashboard'
+import { GroupsGrid } from '@/components/GroupsGrid'
+import { GroupsList } from '@/components/GroupsList'
+import { UserGroupsDashboard } from '@/components/UserGroupsDashboard'
+import { useAuth } from '@/hooks/useAuth'
+
+export default function Dashboard() {
+  const router = useRouter()
+  const { address } = useAuth()
+  const {
+    // ── existing ──
+    viewMode,
+    setViewMode,
+    filterStatus,
+    setFilterStatus,
+    searchQuery,
+    setSearchQuery,
+    sortField,
+    sortDirection,
+    toggleSort,
+    currentPage,
+    setCurrentPage,
+    totalPages,
+    groups,
+    totalGroups,
+    isLoading,
+    // ── new (#213) ──
+    userAddress,
+  } = useDashboard(address || undefined)
+
+  const handleGroupClick = (groupId: string) => {
+    router.push(`/groups/${groupId}`)
+  }
+
+  const handleJoinGroup = (groupId: string) => {
+    // TODO: Implement join group logic
+    console.log('Join group:', groupId)
+  }
+
+  const EmptyState = () => (
+    <div className="animate-fade-in-up text-center py-20 px-6 bg-white dark:bg-slate-800 rounded-2xl border border-surface-200/80 dark:border-slate-700">
+      <div className="empty-state-icon mb-6 animate-float">
+        <svg className="h-10 w-10 text-primary-500 dark:text-indigo-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+        </svg>
+      </div>
+      <h3 className="text-xl font-bold text-surface-900 dark:text-slate-100 mb-2">No groups found</h3>
+      <p className="text-sm text-surface-500 dark:text-slate-400 max-w-sm mx-auto leading-relaxed">
+        {searchQuery || filterStatus !== 'all'
+          ? 'Try adjusting your filters or search query'
+          : 'Get started by creating or joining a savings group'}
+      </p>
+      {!searchQuery && filterStatus === 'all' && (
+        <button
+          onClick={() => router.push('/groups/create')}
+          className="btn-primary mt-8 px-6 py-3 text-sm"
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+          Create Your First Group
+        </button>
+      )}
+    </div>
+  )
+
+  return (
+    <div className="min-h-screen">
+      {/* Header Section — unchanged */}
+      <div className="page-header-gradient">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-10">
+          <div className="animate-fade-in">
+            <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+              <div>
+                <h1 className="text-3xl sm:text-4xl font-extrabold text-surface-900 dark:text-slate-100 tracking-tight">
+                  Dashboard
+                </h1>
+                <p className="mt-2 text-surface-500 dark:text-slate-400 text-sm sm:text-base">
+                  Manage your savings groups
+                </p>
+              </div>
+              {!isLoading && (
+                <div className="stat-pill animate-fade-in">
+                  <svg className="w-4 h-4 opacity-70" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                  {totalGroups} {totalGroups === 1 ? 'group' : 'groups'}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Main Content */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+
+        {/* ── NEW: User Groups Dashboard (#213) ── */}
+        {userAddress && (
+          <div className="animate-fade-in-up" style={{ animationDelay: '50ms' }}>
+            <UserGroupsDashboard
+              groups={groups ?? []}
+              userAddress={userAddress}
+              isLoading={isLoading}
+            />
+          </div>
+        )}
+
+        {/* Controls Bar — unchanged */}
+        <div className="mb-6 space-y-4 animate-fade-in-up" style={{ animationDelay: '100ms' }}>
+          {/* Search + View Toggle Row */}
+          <div className="flex flex-col sm:flex-row gap-4 justify-between items-start sm:items-center">
+            {/* Search */}
+            <div className="relative flex-1 max-w-md w-full">
+              <div className="absolute inset-y-0 left-0 pl-3.5 flex items-center pointer-events-none">
+                <svg className="h-4 w-4 text-surface-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                </svg>
+              </div>
+              <input
+                type="text"
+                placeholder="Search groups..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="input-search"
+              />
+            </div>
+
+            {/* View Toggle */}
+            <div className="view-toggle-group">
+              <button
+                onClick={() => setViewMode('grid')}
+                className={viewMode === 'grid' ? 'view-toggle-btn-active' : 'view-toggle-btn-inactive'}
+              >
+                <span className="flex items-center gap-1.5">
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+                  </svg>
+                  Grid
+                </span>
+              </button>
+              <button
+                onClick={() => setViewMode('list')}
+                className={viewMode === 'list' ? 'view-toggle-btn-active' : 'view-toggle-btn-inactive'}
+              >
+                <span className="flex items-center gap-1.5">
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 10h16M4 14h16M4 18h16" />
+                  </svg>
+                  List
+                </span>
+              </button>
+            </div>
+          </div>
+
+          {/* Filter Buttons */}
+          <div className="flex flex-wrap gap-2">
+            {(['all', 'active', 'completed', 'paused'] as const).map((status) => (
+              <button
+                key={status}
+                onClick={() => setFilterStatus(status)}
+                className={filterStatus === status ? 'filter-btn-active' : 'filter-btn-inactive'}
+              >
+                {status === 'active' && (
+                  <span className="inline-block w-1.5 h-1.5 rounded-full bg-current mr-1.5 opacity-70" />
+                )}
+                {status.charAt(0).toUpperCase() + status.slice(1)}
+              </button>
+            ))}
+          </div>
+
+          {/* Results Count */}
+          {!isLoading && (
+            <div className="text-xs font-medium text-surface-400 tracking-wide uppercase">
+              Showing {(groups ?? []).length} of {totalGroups} groups
+            </div>
+          )}
+        </div>
+
+        {/* Content Area — unchanged */}
+        <div className="animate-fade-in-up" style={{ animationDelay: '200ms' }}>
+          {!isLoading && (groups ?? []).length === 0 ? (
+            <EmptyState />
+          ) : viewMode === 'grid' ? (
+            <GroupsGrid
+              groups={groups ?? []}
+              isLoading={isLoading}
+              onGroupClick={handleGroupClick}
+            />
+          ) : (
+            <GroupsList
+              groups={groups}
+              isLoading={isLoading}
+              onGroupClick={handleGroupClick}
+              onJoinGroup={handleJoinGroup}
+            />
+          )}
+        </div>
+
+        {/* Pagination — unchanged */}
+        {totalPages > 1 && (
+          <div className="mt-8 flex justify-center items-center gap-2 animate-fade-in">
+            <button
+              onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+              disabled={currentPage === 1}
+              className="pagination-btn px-4"
+            >
+              <svg className="w-4 h-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              Previous
+            </button>
+
+            <div className="flex gap-1.5">
+              {[...Array(totalPages)].map((_, i) => (
+                <button
+                  key={i}
+                  onClick={() => setCurrentPage(i + 1)}
+                  className={currentPage === i + 1 ? 'pagination-btn-active' : 'pagination-btn'}
+                >
+                  {i + 1}
+                </button>
+              ))}
+            </div>
+
+            <button
+              onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+              disabled={currentPage === totalPages}
+              className="pagination-btn px-4"
+            >
+              Next
+              <svg className="w-4 h-4 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/[locale]/dashboard/loading.tsx
+++ b/frontend/src/app/[locale]/dashboard/loading.tsx
@@ -1,0 +1,21 @@
+export default function DashboardLoading() {
+  return (
+    <div className="min-h-screen">
+      <div className="page-header-gradient">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-10">
+          <div className="skeleton h-10 w-56 rounded-lg" />
+          <div className="skeleton h-5 w-72 rounded mt-3" />
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 space-y-6">
+        <div className="skeleton h-12 w-full max-w-md rounded-lg" />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="skeleton h-44 w-full rounded-xl" />
+          <div className="skeleton h-44 w-full rounded-xl" />
+          <div className="skeleton h-44 w-full rounded-xl" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/[locale]/dashboard/page.tsx
+++ b/frontend/src/app/[locale]/dashboard/page.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import { GroupCard } from '@/components/GroupCard'
+import { useAuthContext } from '@/context/AuthContext'
+
+export default function DashboardPage() {
+  const [isLoading, setIsLoading] = useState(true)
+  const { isAuthenticated } = useAuthContext()
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoading(false)
+    }, 1500)
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {/* Welcome Section */}
+      <div className="bg-gradient-to-r from-blue-600 to-indigo-600 rounded-xl shadow-lg p-6 md:p-8 mb-8 text-white">
+        <h2 className="text-2xl md:text-3xl font-bold mb-2">
+          {isAuthenticated ? `Welcome back!` : 'Welcome to Ajo'}
+        </h2>
+        <p className="text-blue-100 text-base md:text-lg">
+          {isAuthenticated 
+            ? 'Manage your savings groups and track your contributions.'
+            : 'Connect your wallet to get started with community savings.'}
+        </p>
+      </div>
+
+      {isAuthenticated ? (
+        <>
+          {/* Stat Cards Section */}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+            <div className="bg-white rounded-lg shadow p-6">
+              <h3 className="text-lg font-semibold mb-2">Active Groups</h3>
+              {isLoading ? (
+                <div className="skeleton h-9 w-12 rounded mt-1"></div>
+              ) : (
+                <p className="text-3xl font-bold text-blue-600">0</p>
+              )}
+            </div>
+            
+            <div className="bg-white rounded-lg shadow p-6">
+              <h3 className="text-lg font-semibold mb-2">Total Saved</h3>
+              {isLoading ? (
+                <div className="skeleton h-9 w-24 rounded mt-1"></div>
+              ) : (
+                <p className="text-3xl font-bold text-green-600">$0.00</p>
+              )}
+            </div>
+
+            <div className="bg-white rounded-lg shadow p-6">
+              <h3 className="text-lg font-semibold mb-2">Next Payout</h3>
+              {isLoading ? (
+                <div className="skeleton h-6 w-32 rounded mt-2"></div>
+              ) : (
+                <p className="text-gray-600">None scheduled</p>
+              )}
+            </div>
+          </div>
+
+          {/* Groups List Section */}
+          <div>
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-2xl font-bold">Your Groups</h2>
+              <Link
+                href="/groups/create"
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium flex items-center gap-2"
+              >
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                Create Group
+              </Link>
+            </div>
+            
+            {isLoading ? (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <GroupCard isLoading={true} />
+                <GroupCard isLoading={true} />
+                <GroupCard isLoading={true} />
+              </div>
+            ) : (
+              <div className="bg-white rounded-lg border-2 border-dashed border-gray-300 p-12 text-center">
+                <svg className="w-16 h-16 text-gray-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+                </svg>
+                <h3 className="text-xl font-semibold text-gray-900 mb-2">No groups yet</h3>
+                <p className="text-gray-600 mb-6">Create your first savings group to get started</p>
+                <Link
+                  href="/groups/create"
+                  className="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                  </svg>
+                  Create Your First Group
+                </Link>
+              </div>
+            )}
+          </div>
+        </>
+      ) : (
+        <div className="bg-white rounded-lg shadow-lg p-8 md:p-12 text-center">
+          <svg className="w-20 h-20 text-blue-600 mx-auto mb-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+          </svg>
+          <h3 className="text-2xl font-bold text-gray-900 mb-4">Connect Your Wallet</h3>
+          <p className="text-gray-600 mb-8 max-w-md mx-auto">
+            To access your dashboard and manage your savings groups, please connect your Stellar wallet using the button in the header.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link
+              href="/"
+              className="px-6 py-3 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors font-medium"
+            >
+              Back to Home
+            </Link>
+            <a
+              href="https://www.freighter.app/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+            >
+              Get Freighter Wallet
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/app/[locale]/debug-freighter/page.tsx
+++ b/frontend/src/app/[locale]/debug-freighter/page.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export default function DebugFreighterPage() {
+  const [logs, setLogs] = useState<string[]>([])
+  const [freighterApi, setFreighterApi] = useState<any>(null)
+
+  const addLog = (message: string) => {
+    setLogs(prev => [...prev, `[${new Date().toLocaleTimeString()}] ${message}`])
+    console.log(message)
+  }
+
+  useEffect(() => {
+    addLog('Page loaded, starting Freighter detection...')
+    
+    const detectFreighter = async () => {
+      addLog('Checking window object...')
+      addLog(`window is defined: ${typeof window !== 'undefined'}`)
+      
+      if (typeof window === 'undefined') {
+        addLog('ERROR: window is undefined')
+        return
+      }
+
+      addLog('Checking for freighterApi...')
+      addLog(`window.freighterApi exists: ${!!(window as any).freighterApi}`)
+      
+      if ((window as any).freighterApi) {
+        addLog('✓ Freighter API found immediately!')
+        setFreighterApi((window as any).freighterApi)
+        return
+      }
+
+      addLog('Freighter not found, waiting...')
+      
+      for (let i = 0; i < 50; i++) {
+        await new Promise(resolve => setTimeout(resolve, 100))
+        
+        if ((window as any).freighterApi) {
+          addLog(`✓ Freighter API found after ${(i + 1) * 100}ms!`)
+          setFreighterApi((window as any).freighterApi)
+          return
+        }
+        
+        if (i % 10 === 0) {
+          addLog(`Still waiting... (${(i + 1) * 100}ms elapsed)`)
+        }
+      }
+      
+      addLog('✗ Freighter API not found after 5 seconds')
+      addLog('Checking window properties...')
+      
+      const windowKeys = Object.keys(window).filter(key => 
+        key.toLowerCase().includes('freighter') || 
+        key.toLowerCase().includes('stellar') ||
+        key.toLowerCase().includes('wallet')
+      )
+      
+      if (windowKeys.length > 0) {
+        addLog(`Found related properties: ${windowKeys.join(', ')}`)
+      } else {
+        addLog('No wallet-related properties found on window object')
+      }
+    }
+
+    detectFreighter()
+  }, [])
+
+  const testFreighterMethods = async () => {
+    if (!freighterApi) {
+      addLog('ERROR: No Freighter API available')
+      return
+    }
+
+    try {
+      addLog('Testing isAllowed()...')
+      const allowed = await freighterApi.isAllowed()
+      addLog(`isAllowed() returned: ${allowed}`)
+
+      if (!allowed) {
+        addLog('Requesting permission with setAllowed()...')
+        await freighterApi.setAllowed()
+        addLog('setAllowed() completed')
+      }
+
+      addLog('Testing getPublicKey()...')
+      const publicKey = await freighterApi.getPublicKey()
+      addLog(`✓ Got public key: ${publicKey}`)
+
+      addLog('Testing getNetworkDetails()...')
+      const network = await freighterApi.getNetworkDetails()
+      addLog(`✓ Network: ${JSON.stringify(network)}`)
+
+    } catch (err) {
+      addLog(`ERROR: ${err instanceof Error ? err.message : String(err)}`)
+      console.error('Freighter test error:', err)
+    }
+  }
+
+  const checkExtensions = () => {
+    addLog('Checking for other wallet extensions...')
+    
+    const checks = [
+      { name: 'Freighter', key: 'freighterApi' },
+      { name: 'Albedo', key: 'albedo' },
+      { name: 'xBull', key: 'xBullSDK' },
+      { name: 'Rabet', key: 'rabet' },
+      { name: 'MetaMask', key: 'ethereum' },
+    ]
+
+    checks.forEach(({ name, key }) => {
+      const exists = !!(window as any)[key]
+      addLog(`${name}: ${exists ? '✓ Found' : '✗ Not found'}`)
+    })
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-gray-100 p-8">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold mb-6 text-white">Freighter Debug Console</h1>
+        
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+          <div className={`p-4 rounded-lg ${freighterApi ? 'bg-green-900' : 'bg-red-900'}`}>
+            <div className="text-sm text-gray-300">Freighter Status</div>
+            <div className="text-2xl font-bold">
+              {freighterApi ? '✓ Detected' : '✗ Not Found'}
+            </div>
+          </div>
+          
+          <div className="p-4 rounded-lg bg-blue-900">
+            <div className="text-sm text-gray-300">Logs</div>
+            <div className="text-2xl font-bold">{logs.length}</div>
+          </div>
+          
+          <div className="p-4 rounded-lg bg-purple-900">
+            <div className="text-sm text-gray-300">Browser</div>
+            <div className="text-lg font-bold">
+              {typeof navigator !== 'undefined' 
+                ? navigator.userAgent.includes('Chrome') ? 'Chrome' 
+                : navigator.userAgent.includes('Firefox') ? 'Firefox'
+                : navigator.userAgent.includes('Safari') ? 'Safari'
+                : 'Other'
+                : 'Unknown'}
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4 mb-6">
+          <button
+            onClick={testFreighterMethods}
+            disabled={!freighterApi}
+            className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 disabled:cursor-not-allowed text-white font-semibold py-3 rounded-lg transition"
+          >
+            Test Freighter Methods
+          </button>
+          
+          <button
+            onClick={checkExtensions}
+            className="w-full bg-purple-600 hover:bg-purple-700 text-white font-semibold py-3 rounded-lg transition"
+          >
+            Check All Wallet Extensions
+          </button>
+          
+          <button
+            onClick={() => setLogs([])}
+            className="w-full bg-gray-700 hover:bg-gray-600 text-white font-semibold py-3 rounded-lg transition"
+          >
+            Clear Logs
+          </button>
+        </div>
+
+        <div className="bg-gray-800 rounded-lg p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-xl font-bold">Console Output</h2>
+            <span className="text-sm text-gray-400">{logs.length} entries</span>
+          </div>
+          
+          <div className="bg-black rounded p-4 font-mono text-sm space-y-1 max-h-96 overflow-y-auto">
+            {logs.length === 0 ? (
+              <div className="text-gray-500">Waiting for logs...</div>
+            ) : (
+              logs.map((log, i) => (
+                <div 
+                  key={i} 
+                  className={
+                    log.includes('ERROR') ? 'text-red-400' :
+                    log.includes('✓') ? 'text-green-400' :
+                    log.includes('✗') ? 'text-red-400' :
+                    log.includes('waiting') ? 'text-yellow-400' :
+                    'text-gray-300'
+                  }
+                >
+                  {log}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="mt-6 p-4 bg-gray-800 rounded-lg">
+          <h3 className="font-bold mb-2">Quick Checks:</h3>
+          <ul className="space-y-2 text-sm">
+            <li>• Is Freighter icon visible in your browser toolbar?</li>
+            <li>• Can you click the Freighter icon and see your wallet?</li>
+            <li>• Have you created/imported an account in Freighter?</li>
+            <li>• Did you refresh this page after installing Freighter?</li>
+            <li>• Are you using Chrome, Firefox, Brave, or Edge?</li>
+          </ul>
+        </div>
+
+        <div className="mt-6 p-4 bg-yellow-900 rounded-lg">
+          <h3 className="font-bold mb-2 text-yellow-200">If Freighter is not detected:</h3>
+          <ol className="space-y-2 text-sm text-yellow-100 list-decimal list-inside">
+            <li>Go to your browser's extension page (chrome://extensions/)</li>
+            <li>Find Freighter and make sure it's enabled</li>
+            <li>Click the Freighter icon to open it</li>
+            <li>Make sure you have an account (create or import one)</li>
+            <li>Come back to this page and refresh (F5)</li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/[locale]/groups/[id]/example-integration.tsx
+++ b/frontend/src/app/[locale]/groups/[id]/example-integration.tsx
@@ -1,0 +1,400 @@
+/**
+ * Example Integration: Group Detail Page with Status
+ * 
+ * This file demonstrates how to integrate the GroupStatus component
+ * into a real group detail page. Copy and adapt as needed.
+ * 
+ * Features demonstrated:
+ * - Group status display
+ * - Member list integration
+ * - Transaction history
+ * - Contribution form
+ * - Cache management
+ */
+
+'use client'
+
+import React from 'react'
+import { useParams } from 'next/navigation'
+import { GroupStatus } from '@/components/GroupStatus'
+import { MemberList } from '@/components/MemberList'
+import { TransactionHistory } from '@/components/TransactionHistory'
+import { ContributionForm } from '@/components/ContributionForm'
+import { 
+  useGroupDetail, 
+  useGroupMembers,
+  useGroupStatus,
+  useCacheInvalidation 
+} from '@/hooks/useContractData'
+
+export default function GroupDetailPageExample() {
+  const params = useParams()
+  const groupId = params.id as string
+
+  // Fetch all group data
+  const { data: group, isLoading: groupLoading } = useGroupDetail(groupId)
+  const { data: status, isLoading: statusLoading } = useGroupStatus(groupId)
+  const { data: members, isLoading: membersLoading } = useGroupMembers(groupId)
+
+  // Cache management
+  const { invalidateGroup } = useCacheInvalidation()
+
+  // Handle contribution success
+  const handleContributionSuccess = () => {
+    // Cache is automatically invalidated by the mutation
+    // But you can manually trigger if needed
+    invalidateGroup(groupId)
+  }
+
+  // Loading state
+  if (groupLoading || statusLoading || membersLoading) {
+    return (
+      <div className="container">
+        <div className="loading-skeleton">
+          <div className="skeleton-header" />
+          <div className="skeleton-content" />
+        </div>
+      </div>
+    )
+  }
+
+  // Error state
+  if (!group || !status) {
+    return (
+      <div className="container">
+        <div className="error-state">
+          <h2>Group not found</h2>
+          <p>The group you're looking for doesn't exist or has been removed.</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container">
+      {/* Page Header */}
+      <header className="page-header">
+        <h1>{group.name}</h1>
+        {group.description && (
+          <p className="description">{group.description}</p>
+        )}
+      </header>
+
+      {/* Main Content Grid */}
+      <div className="content-grid">
+        
+        {/* Left Column: Status and Actions */}
+        <aside className="sidebar">
+          
+          {/* Group Status - The star of the show! */}
+          <GroupStatus 
+            groupId={groupId}
+            showRefreshButton={true}
+            className="status-card"
+          />
+
+          {/* Contribution Form */}
+          {status.pendingContributions > 0 && (
+            <ContributionForm
+              groupId={groupId}
+              requiredAmount={group.contributionAmount}
+              onSuccess={handleContributionSuccess}
+            />
+          )}
+
+          {/* Quick Stats */}
+          <div className="quick-stats">
+            <div className="stat">
+              <span className="label">Members</span>
+              <span className="value">{group.currentMembers}/{group.maxMembers}</span>
+            </div>
+            <div className="stat">
+              <span className="label">Contribution</span>
+              <span className="value">{group.contributionAmount} XLM</span>
+            </div>
+            <div className="stat">
+              <span className="label">Cycle Length</span>
+              <span className="value">{group.cycleLength} days</span>
+            </div>
+          </div>
+        </aside>
+
+        {/* Right Column: Members and Transactions */}
+        <main className="main-content">
+          
+          {/* Member List */}
+          <section className="section">
+            <h2>Members</h2>
+            <MemberList 
+              members={members || []}
+              groupId={groupId}
+            />
+          </section>
+
+          {/* Transaction History */}
+          <section className="section">
+            <h2>Transaction History</h2>
+            <TransactionHistory 
+              groupId={groupId}
+              limit={10}
+            />
+          </section>
+
+          {/* Cycle Information */}
+          <section className="section">
+            <h2>Cycle Information</h2>
+            <div className="cycle-info">
+              <p>
+                <strong>Current Cycle:</strong> {status.currentCycle}
+              </p>
+              <p>
+                <strong>Next Recipient:</strong>{' '}
+                {status.nextRecipient === 'N/A' 
+                  ? 'Group Complete' 
+                  : status.nextRecipient
+                }
+              </p>
+              <p>
+                <strong>Contributions Received:</strong>{' '}
+                {group.currentMembers - status.pendingContributions} / {group.currentMembers}
+              </p>
+              <p>
+                <strong>Days Until Payout:</strong> {status.daysUntilPayout}
+              </p>
+            </div>
+          </section>
+        </main>
+      </div>
+
+      <style jsx>{`
+        .container {
+          max-width: 1200px;
+          margin: 0 auto;
+          padding: 2rem;
+        }
+
+        .page-header {
+          margin-bottom: 2rem;
+        }
+
+        .page-header h1 {
+          font-size: 2rem;
+          font-weight: 700;
+          color: var(--text-primary);
+          margin-bottom: 0.5rem;
+        }
+
+        .description {
+          font-size: 1rem;
+          color: var(--text-secondary);
+        }
+
+        .content-grid {
+          display: grid;
+          grid-template-columns: 350px 1fr;
+          gap: 2rem;
+        }
+
+        .sidebar {
+          display: flex;
+          flex-direction: column;
+          gap: 1.5rem;
+        }
+
+        .status-card {
+          position: sticky;
+          top: 2rem;
+        }
+
+        .quick-stats {
+          background: var(--surface-primary);
+          border: 1px solid var(--border-primary);
+          border-radius: 12px;
+          padding: 1.5rem;
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+        }
+
+        .stat {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+
+        .stat .label {
+          font-size: 0.875rem;
+          color: var(--text-secondary);
+        }
+
+        .stat .value {
+          font-size: 1rem;
+          font-weight: 600;
+          color: var(--text-primary);
+        }
+
+        .main-content {
+          display: flex;
+          flex-direction: column;
+          gap: 2rem;
+        }
+
+        .section {
+          background: var(--surface-primary);
+          border: 1px solid var(--border-primary);
+          border-radius: 12px;
+          padding: 1.5rem;
+        }
+
+        .section h2 {
+          font-size: 1.25rem;
+          font-weight: 600;
+          color: var(--text-primary);
+          margin-bottom: 1rem;
+        }
+
+        .cycle-info {
+          display: flex;
+          flex-direction: column;
+          gap: 0.75rem;
+        }
+
+        .cycle-info p {
+          font-size: 0.875rem;
+          color: var(--text-secondary);
+        }
+
+        .cycle-info strong {
+          color: var(--text-primary);
+          font-weight: 600;
+        }
+
+        .loading-skeleton {
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+        }
+
+        .skeleton-header,
+        .skeleton-content {
+          height: 100px;
+          background: linear-gradient(
+            90deg,
+            var(--surface-secondary) 25%,
+            var(--surface-tertiary) 50%,
+            var(--surface-secondary) 75%
+          );
+          background-size: 200% 100%;
+          animation: shimmer 1.5s infinite;
+          border-radius: 8px;
+        }
+
+        .skeleton-content {
+          height: 400px;
+        }
+
+        @keyframes shimmer {
+          0% {
+            background-position: 200% 0;
+          }
+          100% {
+            background-position: -200% 0;
+          }
+        }
+
+        .error-state {
+          text-align: center;
+          padding: 4rem 2rem;
+        }
+
+        .error-state h2 {
+          font-size: 1.5rem;
+          color: var(--text-primary);
+          margin-bottom: 0.5rem;
+        }
+
+        .error-state p {
+          color: var(--text-secondary);
+        }
+
+        @media (max-width: 968px) {
+          .content-grid {
+            grid-template-columns: 1fr;
+          }
+
+          .status-card {
+            position: static;
+          }
+        }
+      `}</style>
+    </div>
+  )
+}
+
+/**
+ * Alternative: Minimal Integration
+ * 
+ * If you just want to add status to an existing page:
+ */
+export function MinimalIntegration({ groupId }: { groupId: string }) {
+  return (
+    <div>
+      <h1>Group Details</h1>
+      
+      {/* Just drop in the component */}
+      <GroupStatus groupId={groupId} />
+      
+      {/* Rest of your existing page */}
+    </div>
+  )
+}
+
+/**
+ * Alternative: Custom Status Display
+ * 
+ * If you want to build your own UI:
+ */
+export function CustomStatusDisplay({ groupId }: { groupId: string }) {
+  const { data, isLoading, error, refetch } = useGroupStatus(groupId)
+
+  if (isLoading) return <div>Loading...</div>
+  if (error) return <div>Error: {error.message}</div>
+  if (!data) return null
+
+  return (
+    <div className="custom-status">
+      <h2>Group Status</h2>
+      
+      <div className="status-grid">
+        <div>Cycle: {data.currentCycle}</div>
+        <div>Pending: {data.pendingContributions}</div>
+        <div>Collected: {data.totalCollected} XLM</div>
+        <div>Days Left: {data.daysUntilPayout}</div>
+      </div>
+
+      <button onClick={() => refetch()}>
+        Refresh
+      </button>
+    </div>
+  )
+}
+
+/**
+ * Alternative: Status with Auto-refresh
+ * 
+ * Automatically refresh every minute:
+ */
+export function AutoRefreshStatus({ groupId }: { groupId: string }) {
+  const { data, refetch } = useGroupStatus(groupId)
+
+  // Auto-refresh every 60 seconds
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      refetch()
+    }, 60000)
+
+    return () => clearInterval(interval)
+  }, [refetch])
+
+  return <GroupStatus groupId={groupId} />
+}

--- a/frontend/src/app/[locale]/groups/[id]/example-integration.tsx
+++ b/frontend/src/app/[locale]/groups/[id]/example-integration.tsx
@@ -64,7 +64,7 @@ export default function GroupDetailPageExample() {
       <div className="container">
         <div className="error-state">
           <h2>Group not found</h2>
-          <p>The group you're looking for doesn't exist or has been removed.</p>
+          <p>The group you&apos;re looking for doesn't exist or has been removed.</p>
         </div>
       </div>
     )

--- a/frontend/src/app/[locale]/groups/[id]/page.tsx
+++ b/frontend/src/app/[locale]/groups/[id]/page.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+import { GroupDetailPage } from '@/components/GroupDetailPage'
+
+export default function GroupPage() {
+  const params = useParams()
+  const groupId = params?.id as string
+
+  if (!groupId) return null
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-slate-900 px-4 py-8">
+      <div className="max-w-6xl mx-auto">
+        <GroupDetailPage groupId={groupId} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/[locale]/groups/loading.tsx
+++ b/frontend/src/app/[locale]/groups/loading.tsx
@@ -1,0 +1,21 @@
+export default function GroupsLoading() {
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4 max-w-7xl space-y-6">
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+          <div className="space-y-2">
+            <div className="skeleton h-9 w-56 rounded" />
+            <div className="skeleton h-5 w-72 rounded" />
+          </div>
+          <div className="skeleton h-12 w-40 rounded-lg" />
+        </div>
+
+        <div className="space-y-4">
+          <div className="skeleton h-24 w-full rounded-xl" />
+          <div className="skeleton h-24 w-full rounded-xl" />
+          <div className="skeleton h-24 w-full rounded-xl" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/[locale]/groups/page.tsx
+++ b/frontend/src/app/[locale]/groups/page.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { GroupsList } from '@/components/GroupsList'
+import { GroupCreationForm } from '@/components/GroupCreationForm'
+import { useDashboard } from '@/hooks/useDashboard'
+import { useState } from 'react'
+import { SearchBar } from '@/components/SearchBar'
+import { FilterPanel } from '@/components/FilterPanel'
+import { useGroupFilters } from '@/hooks/useGroupFilters'
+
+export default function GroupsPage() {
+  const [showCreateForm, setShowCreateForm] = useState(false)
+  const { groups: rawGroups, isLoading } = useDashboard()
+
+  const { filters, updateFilter, clearFilters, filteredAndSortedGroups } = useGroupFilters(rawGroups);
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="container mx-auto px-4 max-w-7xl">
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-8">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Savings Groups</h1>
+            <p className="text-gray-600 mt-1">Create and manage your Ajo savings groups</p>
+          </div>
+          <button
+            onClick={() => setShowCreateForm(!showCreateForm)}
+            className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium shadow-sm flex items-center gap-2"
+          >
+            {showCreateForm ? (
+              <>
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                </svg>
+                View Groups
+              </>
+            ) : (
+              <>
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                Create Group
+              </>
+            )}
+          </button>
+        </div>
+
+        {showCreateForm ? (
+          <GroupCreationForm onSuccess={() => setShowCreateForm(false)} />
+        ) : (
+          <div className="space-y-4">
+            <div className="flex flex-col gap-4 mb-4">
+              <SearchBar
+                value={filters.searchQuery}
+                onChange={(val) => updateFilter('searchQuery', val)}
+              />
+              <FilterPanel
+                filters={filters}
+                updateFilter={updateFilter}
+                clearFilters={clearFilters}
+              />
+            </div>
+            {filteredAndSortedGroups.length === 0 && !isLoading ? (
+              <div className="text-center py-12 bg-white rounded-xl shadow-sm border border-gray-100">
+                <p className="text-gray-500">No groups found matching your criteria.</p>
+                <button
+                  onClick={clearFilters}
+                  className="mt-4 text-blue-600 hover:underline"
+                >
+                  Clear all filters
+                </button>
+              </div>
+            ) : (
+              <GroupsList
+                groups={filteredAndSortedGroups}
+                isLoading={isLoading}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -1,0 +1,109 @@
+import { NextIntlClientProvider } from 'next-intl';
+import { getMessages } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+import type { Metadata, Viewport } from 'next';
+import { Inter } from 'next/font/google';
+import '../../styles/globals.css';
+import { Providers } from '../providers';
+import { AppLayout } from '@/components/AppLayout';
+import { InstallPrompt } from '@/components/InstallPrompt';
+import { OfflineIndicator } from '@/components/OfflineIndicator';
+import { locales } from '@/i18n';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'Ajo - Decentralized Savings Groups',
+  description: 'Join and manage savings groups on the Stellar blockchain',
+  manifest: '/manifest.json',
+  icons: {
+    icon: '/favicon.ico',
+    apple: '/apple-touch-icon.png',
+    other: [
+      {
+        rel: 'icon',
+        type: 'image/png',
+        sizes: '192x192',
+        url: '/icon-192.png',
+      },
+      {
+        rel: 'icon',
+        type: 'image/png',
+        sizes: '512x512',
+        url: '/icon-512.png',
+      },
+    ],
+  },
+  openGraph: {
+    title: 'Ajo - Decentralized Savings Groups',
+    description: 'Join and manage savings groups on the Stellar blockchain',
+    url: 'https://ajo.stellar.org',
+    siteName: 'Ajo',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+      },
+    ],
+    locale: 'en_US',
+    type: 'website',
+  },
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'default',
+    title: 'Ajo',
+  },
+};
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#3b82f6' },
+    { media: '(prefers-color-scheme: dark)', color: '#1e40af' },
+  ],
+};
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export default async function LocaleLayout({
+  children,
+  params: { locale }
+}: {
+  children: React.ReactNode;
+  params: { locale: string };
+}) {
+  if (!locales.includes(locale as any)) {
+    notFound();
+  }
+
+  const messages = await getMessages();
+
+  return (
+    <html lang={locale}>
+      <head>
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+        <meta name="apple-mobile-web-app-title" content="Ajo" />
+      </head>
+      <body className={inter.className}>
+        <div className="pattern-overlay gradient-mesh min-h-screen">
+          <NextIntlClientProvider messages={messages}>
+            <Providers>
+              <AppLayout>{children}</AppLayout>
+              <InstallPrompt />
+              <OfflineIndicator />
+            </Providers>
+          </NextIntlClientProvider>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/src/app/[locale]/offline/page.tsx
+++ b/frontend/src/app/[locale]/offline/page.tsx
@@ -1,0 +1,39 @@
+import { WifiOff } from 'lucide-react'
+
+export default function OfflinePage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
+      <div className="text-center max-w-md">
+        <div className="inline-flex items-center justify-center w-20 h-20 bg-orange-100 dark:bg-orange-900 rounded-full mb-6">
+          <WifiOff className="w-10 h-10 text-orange-600 dark:text-orange-400" />
+        </div>
+        
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
+          You're Offline
+        </h1>
+        
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          It looks like you've lost your internet connection. Some features may not be available until you're back online.
+        </p>
+        
+        <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 text-left">
+          <h2 className="font-semibold text-blue-900 dark:text-blue-100 mb-2">
+            What you can still do:
+          </h2>
+          <ul className="text-sm text-blue-800 dark:text-blue-200 space-y-1">
+            <li>• View previously loaded pages</li>
+            <li>• Browse cached content</li>
+            <li>• Access your profile</li>
+          </ul>
+        </div>
+        
+        <button
+          onClick={() => window.location.reload()}
+          className="mt-6 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+        >
+          Try Again
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/app/[locale]/offline/page.tsx
+++ b/frontend/src/app/[locale]/offline/page.tsx
@@ -9,11 +9,11 @@ export default function OfflinePage() {
         </div>
         
         <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-4">
-          You're Offline
+          You&apos;re Offline
         </h1>
         
         <p className="text-gray-600 dark:text-gray-400 mb-6">
-          It looks like you've lost your internet connection. Some features may not be available until you're back online.
+          It looks like you&apos;ve lost your internet connection. Some features may not be available until you&apos;re back online.
         </p>
         
         <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 text-left">

--- a/frontend/src/app/[locale]/page.tsx
+++ b/frontend/src/app/[locale]/page.tsx
@@ -1,0 +1,83 @@
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+
+export default function HomePage() {
+  const t = useTranslations('home');
+  const tCommon = useTranslations('common');
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50">
+      {/* Hero Section */}
+      <div className="container mx-auto px-4 py-16 md:py-20">
+        <div className="text-center max-w-4xl mx-auto">
+          <h1 className="text-4xl md:text-6xl font-bold text-gray-900 mb-6">
+            {t('hero.title')}
+          </h1>
+          <p className="text-xl md:text-2xl text-gray-700 mb-4">
+            {t('hero.subtitle')}
+          </p>
+          <p className="text-base md:text-lg text-gray-600 mb-12 max-w-2xl mx-auto">
+            {t('hero.description')}
+          </p>
+          
+          <div className="flex flex-col sm:flex-row gap-4 justify-center mb-16">
+            <Link
+              href="/dashboard"
+              className="px-8 py-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-semibold text-lg shadow-lg hover:shadow-xl"
+            >
+              {tCommon('getStarted')}
+            </Link>
+            <Link
+              href="/community"
+              className="px-8 py-4 bg-white text-blue-600 border-2 border-blue-600 rounded-lg hover:bg-blue-50 transition-colors font-semibold text-lg"
+            >
+              {tCommon('learnMore')}
+            </Link>
+          </div>
+        </div>
+
+        {/* How It Works */}
+        <div className="max-w-5xl mx-auto mb-20">
+          <h2 className="text-2xl md:text-3xl font-bold text-center mb-12 text-gray-900">
+            {t('howItWorks.title')}
+          </h2>
+          <div className="grid md:grid-cols-3 gap-8">
+            <div className="bg-white p-6 md:p-8 rounded-xl shadow-md text-center">
+              <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl font-bold text-blue-600">1</span>
+              </div>
+              <h3 className="text-lg md:text-xl font-semibold mb-3 text-gray-900">
+                {t('howItWorks.step1.title')}
+              </h3>
+              <p className="text-gray-600 text-sm md:text-base">
+                {t('howItWorks.step1.description')}
+              </p>
+            </div>
+            <div className="bg-white p-6 md:p-8 rounded-xl shadow-md text-center">
+              <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl font-bold text-blue-600">2</span>
+              </div>
+              <h3 className="text-lg md:text-xl font-semibold mb-3 text-gray-900">
+                {t('howItWorks.step2.title')}
+              </h3>
+              <p className="text-gray-600 text-sm md:text-base">
+                {t('howItWorks.step2.description')}
+              </p>
+            </div>
+            <div className="bg-white p-6 md:p-8 rounded-xl shadow-md text-center">
+              <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl font-bold text-blue-600">3</span>
+              </div>
+              <h3 className="text-lg md:text-xl font-semibold mb-3 text-gray-900">
+                {t('howItWorks.step3.title')}
+              </h3>
+              <p className="text-gray-600 text-sm md:text-base">
+                {t('howItWorks.step3.description')}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/[locale]/profile/page.tsx
+++ b/frontend/src/app/[locale]/profile/page.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/hooks/useAuth'
+import { useProfile } from '@/hooks/useProfile'
+import { ProfileCard } from '@/components/ProfileCard'
+import { ProfileForm } from '@/components/ProfileForm'
+import { SettingsPanel } from '@/components/SettingsPanel'
+import type { ActivityItem } from '@/types/profile'
+
+export default function ProfilePage() {
+  const router = useRouter()
+  const { isAuthenticated, address, logout } = useAuth()
+  const { profile, activities, isLoading, updateProfile, savePreferences } = useProfile()
+  const [activeSection, setActiveSection] = useState<'overview' | 'edit' | 'settings' | 'activity'>('overview')
+
+  // Redirect to dashboard if not authenticated
+  React.useEffect(() => {
+    if (!isAuthenticated) {
+      router.push('/dashboard')
+    }
+  }, [isAuthenticated, router])
+
+  if (!isAuthenticated || !profile) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-slate-900 flex items-center justify-center">
+        <div className="text-center">
+          <div className="w-16 h-16 border-4 border-blue-600 dark:border-indigo-400 border-t-transparent rounded-full animate-spin mx-auto mb-4" />
+          <p className="text-gray-600 dark:text-slate-400">Loading profile...</p>
+        </div>
+      </div>
+    )
+  }
+
+  const sections = [
+    { id: 'overview', label: 'Overview', icon: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z' },
+    { id: 'edit', label: 'Edit Profile', icon: 'M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z' },
+    { id: 'settings', label: 'Settings', icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z' },
+    { id: 'activity', label: 'Activity', icon: 'M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z' },
+  ]
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-slate-900">
+      {/* Header */}
+      <header className="bg-white dark:bg-slate-800 shadow-sm border-b border-gray-200 dark:border-slate-700">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <button
+                onClick={() => router.push('/dashboard')}
+                className="p-2 hover:bg-gray-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
+              >
+                <svg className="w-6 h-6 text-gray-600 dark:text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                </svg>
+              </button>
+              <div>
+                <h1 className="text-2xl font-bold text-gray-900 dark:text-slate-100">Profile</h1>
+                <p className="text-sm text-gray-600 dark:text-slate-400">Manage your account and preferences</p>
+              </div>
+            </div>
+            <button
+              onClick={logout}
+              className="px-4 py-2 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 rounded-lg transition-colors font-medium flex items-center gap-2"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+              </svg>
+              Logout
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
+          {/* Sidebar */}
+          <div className="lg:col-span-1">
+            <nav className="bg-white dark:bg-slate-800 rounded-xl shadow-lg dark:shadow-slate-900/50 p-4 space-y-1 border border-gray-100 dark:border-slate-700">
+              {sections.map((section) => (
+                <button
+                  key={section.id}
+                  onClick={() => setActiveSection(section.id as typeof activeSection)}
+                  className={`w-full flex items-center gap-3 px-4 py-3 rounded-lg transition-colors text-left ${
+                    activeSection === section.id
+                      ? 'bg-blue-50 dark:bg-indigo-900/40 text-blue-600 dark:text-indigo-400 font-medium'
+                      : 'text-gray-700 dark:text-slate-300 hover:bg-gray-50 dark:hover:bg-slate-700'
+                  }`}
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={section.icon} />
+                  </svg>
+                  {section.label}
+                </button>
+              ))}
+            </nav>
+
+            {/* Wallet Info */}
+            <div className="mt-6 bg-white dark:bg-slate-800 rounded-xl shadow-lg dark:shadow-slate-900/50 p-6 border border-gray-100 dark:border-slate-700">
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-slate-100 mb-3">Connected Wallet</h3>
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <div className="w-2 h-2 bg-green-500 dark:bg-emerald-400 rounded-full" />
+                  <span className="text-xs text-gray-600 dark:text-slate-400">Connected</span>
+                </div>
+                <div className="font-mono text-xs text-gray-800 dark:text-slate-200 bg-gray-50 dark:bg-slate-700/50 p-2 rounded break-all">
+                  {address}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Main Content */}
+          <div className="lg:col-span-3 space-y-6">
+            {activeSection === 'overview' && (
+              <>
+                <ProfileCard profile={profile} isLoading={isLoading} />
+                
+                {/* Quick Stats */}
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                  <StatCard
+                    title="Active Groups"
+                    value={profile.stats.activeGroups}
+                    icon="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                    color="blue"
+                  />
+                  <StatCard
+                    title="Completed Groups"
+                    value={profile.stats.completedGroups}
+                    icon="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                    color="green"
+                  />
+                  <StatCard
+                    title="Total Payouts"
+                    value={`$${profile.stats.totalPayouts.toFixed(2)}`}
+                    icon="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                    color="purple"
+                  />
+                </div>
+              </>
+            )}
+
+            {activeSection === 'edit' && (
+              <ProfileForm profile={profile} onSave={updateProfile} isLoading={isLoading} />
+            )}
+
+            {activeSection === 'settings' && (
+              <SettingsPanel preferences={profile.preferences} onSave={savePreferences} isLoading={isLoading} />
+            )}
+
+            {activeSection === 'activity' && (
+              <ActivityHistory activities={activities} isLoading={isLoading} />
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Helper Components
+interface StatCardProps {
+  title: string
+  value: string | number
+  icon: string
+  color: 'blue' | 'green' | 'purple'
+}
+
+const StatCard: React.FC<StatCardProps> = ({ title, value, icon, color }) => {
+  const colorClasses = {
+    blue: 'from-blue-500 to-blue-600',
+    green: 'from-green-500 to-green-600',
+    purple: 'from-purple-500 to-purple-600',
+  }
+
+  return (
+    <div className="bg-white dark:bg-slate-800 rounded-xl shadow-lg dark:shadow-slate-900/50 p-6 border border-gray-100 dark:border-slate-700">
+      <div className="flex items-center gap-4">
+        <div className={`w-12 h-12 rounded-lg bg-gradient-to-br ${colorClasses[color]} flex items-center justify-center`}>
+          <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={icon} />
+          </svg>
+        </div>
+        <div>
+          <div className="text-2xl font-bold text-gray-900 dark:text-slate-100">{value}</div>
+          <div className="text-sm text-gray-600 dark:text-slate-400">{title}</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface ActivityHistoryProps {
+  activities: ActivityItem[]
+  isLoading: boolean
+}
+
+const ActivityHistory: React.FC<ActivityHistoryProps> = ({ activities, isLoading }) => {
+  if (isLoading) {
+    return (
+      <div className="bg-white dark:bg-slate-800 rounded-xl shadow-lg dark:shadow-slate-900/50 p-8 border border-gray-100 dark:border-slate-700">
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex gap-4">
+              <div className="skeleton w-10 h-10 rounded-full" />
+              <div className="flex-1 space-y-2">
+                <div className="skeleton h-4 w-3/4 rounded" />
+                <div className="skeleton h-3 w-1/2 rounded" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (activities.length === 0) {
+    return (
+      <div className="bg-white dark:bg-slate-800 rounded-xl shadow-lg dark:shadow-slate-900/50 p-12 text-center border border-gray-100 dark:border-slate-700">
+        <svg className="w-16 h-16 text-gray-400 dark:text-slate-500 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <h3 className="text-xl font-semibold text-gray-900 dark:text-slate-100 mb-2">No Activity Yet</h3>
+        <p className="text-gray-600 dark:text-slate-400">Your activity history will appear here</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white dark:bg-slate-800 rounded-xl shadow-lg dark:shadow-slate-900/50 p-8 border border-gray-100 dark:border-slate-700">
+      <h3 className="text-xl font-bold text-gray-900 dark:text-slate-100 mb-6">Recent Activity</h3>
+      <div className="space-y-4">
+        {activities.map((activity) => (
+          <ActivityItem key={activity.id} activity={activity} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface ActivityItemProps {
+  activity: ActivityItem
+}
+
+const ActivityItem: React.FC<ActivityItemProps> = ({ activity }) => {
+  const typeConfig = {
+    contribution: { icon: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z', bg: 'bg-blue-100 dark:bg-blue-900/30', text: 'text-blue-600 dark:text-blue-400' },
+    payout: { icon: 'M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z', bg: 'bg-green-100 dark:bg-green-900/30', text: 'text-green-600 dark:text-green-400' },
+    group_joined: { icon: 'M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z', bg: 'bg-purple-100 dark:bg-purple-900/30', text: 'text-purple-600 dark:text-purple-400' },
+    group_created: { icon: 'M12 4v16m8-8H4', bg: 'bg-indigo-100 dark:bg-indigo-900/30', text: 'text-indigo-600 dark:text-indigo-400' },
+  }
+
+  const config = typeConfig[activity.type]
+
+  return (
+    <div className="flex items-start gap-4 p-4 hover:bg-gray-50 dark:hover:bg-slate-700/50 rounded-lg transition-colors">
+      <div className={`w-10 h-10 rounded-full flex items-center justify-center flex-shrink-0 ${config.bg}`}>
+        <svg className={`w-5 h-5 ${config.text}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={config.icon} />
+        </svg>
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900 dark:text-slate-100">{activity.groupName}</p>
+        {activity.amount && (
+          <p className="text-sm text-gray-600 dark:text-slate-400">${activity.amount.toFixed(2)}</p>
+        )}
+        <p className="text-xs text-gray-500 dark:text-slate-500 mt-1">
+          {new Date(activity.timestamp).toLocaleString()}
+        </p>
+      </div>
+      <span className={`text-xs px-2 py-1 rounded-full ${
+        activity.status === 'completed' ? 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300' :
+        activity.status === 'pending' ? 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300' :
+        'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300'
+      }`}>
+        {activity.status}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/app/[locale]/test-wallet/page.tsx
+++ b/frontend/src/app/[locale]/test-wallet/page.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+export default function TestWalletPage() {
+  const [freighterInstalled, setFreighterInstalled] = useState(false)
+  const [freighterAllowed, setFreighterAllowed] = useState(false)
+  const [publicKey, setPublicKey] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [checking, setChecking] = useState(true)
+
+  useEffect(() => {
+    // Freighter injects its API asynchronously, so we need to wait for it
+    const checkFreighter = async () => {
+      setChecking(true)
+      
+      // Wait up to 3 seconds for Freighter to load
+      for (let i = 0; i < 30; i++) {
+        if (typeof window !== 'undefined' && (window as any).freighterApi) {
+          setFreighterInstalled(true)
+          await checkFreighterPermission()
+          setChecking(false)
+          return
+        }
+        await new Promise(resolve => setTimeout(resolve, 100))
+      }
+      
+      // After 3 seconds, assume it's not installed
+      setFreighterInstalled(false)
+      setChecking(false)
+    }
+
+    checkFreighter()
+  }, [])
+
+  const checkFreighterPermission = async () => {
+    try {
+      const freighter = (window as any).freighterApi
+      const allowed = await freighter.isAllowed()
+      setFreighterAllowed(allowed)
+    } catch (err) {
+      console.error('Error checking Freighter permission:', err)
+    }
+  }
+
+  const handleConnect = async () => {
+    setLoading(true)
+    setError(null)
+    
+    try {
+      if (!(window as any).freighterApi) {
+        throw new Error('Freighter wallet is not installed')
+      }
+
+      const freighter = (window as any).freighterApi
+      
+      // Request permission if not already allowed
+      const isAllowed = await freighter.isAllowed()
+      if (!isAllowed) {
+        await freighter.setAllowed()
+      }
+
+      // Get public key
+      const key = await freighter.getPublicKey()
+      setPublicKey(key)
+      setFreighterAllowed(true)
+      
+      console.log('Successfully connected:', key)
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : 'Unknown error'
+      setError(errorMsg)
+      console.error('Connection error:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="max-w-2xl mx-auto px-4">
+        <div className="bg-white rounded-xl shadow-lg p-8">
+          <h1 className="text-3xl font-bold mb-6">Wallet Connection Test</h1>
+          
+          {checking ? (
+            <div className="mb-8 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+              <div className="flex items-center gap-3">
+                <div className="w-5 h-5 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
+                <span className="text-blue-700">Checking for Freighter wallet...</span>
+              </div>
+            </div>
+          ) : (
+            <>
+              {/* Status Checks */}
+              <div className="space-y-4 mb-8">
+                <div className="flex items-center gap-3">
+                  <div className={`w-3 h-3 rounded-full ${freighterInstalled ? 'bg-green-500' : 'bg-red-500'}`} />
+                  <span className="text-gray-700">
+                    Freighter Installed: {freighterInstalled ? 'Yes ✓' : 'No ✗'}
+                  </span>
+                </div>
+                
+                {freighterInstalled && (
+                  <div className="flex items-center gap-3">
+                    <div className={`w-3 h-3 rounded-full ${freighterAllowed ? 'bg-green-500' : 'bg-yellow-500'}`} />
+                    <span className="text-gray-700">
+                      Permission Granted: {freighterAllowed ? 'Yes ✓' : 'Not yet'}
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              {/* Error Display */}
+              {error && (
+                <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
+                  <p className="text-red-700 font-medium">Error:</p>
+                  <p className="text-red-600 text-sm mt-1">{error}</p>
+                </div>
+              )}
+
+              {/* Public Key Display */}
+              {publicKey && (
+                <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg">
+                  <p className="text-green-700 font-medium mb-2">Connected! ✓</p>
+                  <p className="text-xs text-gray-600 mb-1">Public Key:</p>
+                  <p className="font-mono text-sm text-gray-800 break-all">{publicKey}</p>
+                </div>
+              )}
+
+              {/* Connect Button */}
+              <button
+                onClick={handleConnect}
+                disabled={loading || !freighterInstalled}
+                className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white font-semibold py-3 rounded-lg transition"
+              >
+                {loading ? 'Connecting...' : publicKey ? 'Reconnect' : 'Connect Wallet'}
+              </button>
+
+              {/* Instructions */}
+              {!freighterInstalled && (
+                <div className="mt-6 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+                  <p className="text-yellow-800 font-medium mb-2">Freighter Not Detected</p>
+                  <p className="text-yellow-700 text-sm mb-3">
+                    If you just installed Freighter, try these steps:
+                  </p>
+                  <ol className="text-yellow-700 text-sm space-y-2 mb-4 list-decimal list-inside">
+                    <li>Refresh this page (F5 or Cmd+R)</li>
+                    <li>Make sure the extension is enabled in your browser</li>
+                    <li>Try restarting your browser</li>
+                    <li>Check if Freighter icon appears in your browser toolbar</li>
+                  </ol>
+                  <a
+                    href="https://freighter.app"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-block bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition"
+                  >
+                    Install/Reinstall Freighter
+                  </a>
+                </div>
+              )}
+
+              {/* Debug Info */}
+              <div className="mt-8 p-4 bg-gray-50 rounded-lg space-y-2">
+                <p className="text-xs font-semibold text-gray-700 mb-2">Debug Information:</p>
+                <p className="text-xs font-mono text-gray-600">
+                  freighterApi exists: {typeof window !== 'undefined' && (window as any).freighterApi ? 'true' : 'false'}
+                </p>
+                <p className="text-xs font-mono text-gray-600">
+                  Browser: {typeof window !== 'undefined' ? navigator.userAgent.split(' ').slice(-2).join(' ') : 'unknown'}
+                </p>
+                <p className="text-xs font-mono text-gray-600">
+                  Window loaded: {typeof window !== 'undefined' ? 'true' : 'false'}
+                </p>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/LanguageSelector.tsx
+++ b/frontend/src/components/LanguageSelector.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useLocale, useTranslations } from 'next-intl';
+import { locales, type Locale } from '@/i18n';
+import { useTransition } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
+
+export default function LanguageSelector() {
+  const t = useTranslations('language');
+  const locale = useLocale();
+  const router = useRouter();
+  const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+
+  const handleLanguageChange = (newLocale: string) => {
+    if (newLocale === locale) return;
+
+    // Store preference
+    localStorage.setItem('preferredLocale', newLocale);
+
+    // Update URL
+    startTransition(() => {
+      const newPath = pathname.replace(`/${locale}`, `/${newLocale}`);
+      router.replace(newPath);
+    });
+  };
+
+  return (
+    <div className="relative">
+      <select
+        value={locale}
+        onChange={(e) => handleLanguageChange(e.target.value)}
+        disabled={isPending}
+        className="px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+        aria-label={t('select')}
+      >
+        {locales.map((loc) => (
+          <option key={loc} value={loc}>
+            {t(loc)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -8,6 +8,7 @@ import { UserMenu } from './UserMenu'
 import { MobileMenu } from './MobileMenu'
 import Image from 'next/image'
 import { useTheme } from 'next-themes'
+import LanguageSelector from './LanguageSelector'
 
 export const TopNav: React.FC = () => {
   const pathname = usePathname() || ''
@@ -32,12 +33,6 @@ export const TopNav: React.FC = () => {
             </Link>
           </div>
 
-          <div className="flex items-center gap-4">
-
-            <div className="hidden sm:block">
-            </div>
-          </div>
-
           {/* Desktop Nav */}
           <nav className="hidden md:flex gap-2 items-center">
             {navLinks.map((link) => {
@@ -53,6 +48,7 @@ export const TopNav: React.FC = () => {
                 </Link>
               )
             })}
+            <LanguageSelector />
             <UserMenu />
           </nav>
 

--- a/frontend/src/hooks/useTranslation.ts
+++ b/frontend/src/hooks/useTranslation.ts
@@ -1,0 +1,34 @@
+import { useTranslations as useNextIntlTranslations, useFormatter } from 'next-intl';
+
+export function useTranslation(namespace?: string) {
+  const t = useNextIntlTranslations(namespace);
+  const format = useFormatter();
+
+  return {
+    t,
+    formatDate: (date: Date | number, options?: Intl.DateTimeFormatOptions) => 
+      format.dateTime(date, options),
+    formatNumber: (value: number, options?: Intl.NumberFormatOptions) => 
+      format.number(value, options),
+    formatCurrency: (value: number, currency = 'XLM') => {
+      if (currency === 'XLM') {
+        return `${format.number(value, { minimumFractionDigits: 2, maximumFractionDigits: 7 })} XLM`;
+      }
+      return format.number(value, { style: 'currency', currency });
+    },
+    formatRelativeTime: (date: Date | number) => {
+      const now = Date.now();
+      const timestamp = typeof date === 'number' ? date : date.getTime();
+      const diff = now - timestamp;
+      const seconds = Math.floor(diff / 1000);
+      const minutes = Math.floor(seconds / 60);
+      const hours = Math.floor(minutes / 60);
+      const days = Math.floor(hours / 24);
+
+      return format.relativeTime(
+        days || hours || minutes || seconds,
+        days ? 'day' : hours ? 'hour' : minutes ? 'minute' : 'second'
+      );
+    }
+  };
+}

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -1,0 +1,13 @@
+import { getRequestConfig } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+
+export const locales = ['en', 'es', 'fr', 'pt', 'sw'] as const;
+export type Locale = (typeof locales)[number];
+
+export default getRequestConfig(async ({ locale }) => {
+  if (!locales.includes(locale as Locale)) notFound();
+
+  return {
+    messages: (await import(`./locales/${locale}.json`)).default
+  };
+});

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -1,0 +1,190 @@
+{
+  "common": {
+    "appName": "Ajo",
+    "loading": "Loading...",
+    "error": "Error",
+    "success": "Success",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "save": "Save",
+    "delete": "Delete",
+    "edit": "Edit",
+    "close": "Close",
+    "back": "Back",
+    "next": "Next",
+    "submit": "Submit",
+    "search": "Search",
+    "filter": "Filter",
+    "clear": "Clear",
+    "viewDetails": "View Details",
+    "learnMore": "Learn More",
+    "getStarted": "Get Started"
+  },
+  "nav": {
+    "home": "Home",
+    "dashboard": "Dashboard",
+    "groups": "Groups",
+    "profile": "Profile",
+    "analytics": "Analytics",
+    "community": "Community",
+    "settings": "Settings"
+  },
+  "home": {
+    "hero": {
+      "title": "Save together. Grow together.",
+      "subtitle": "Traditional savings, blockchain trust",
+      "description": "Ajo is a community-based savings system where groups contribute together and take turns receiving payouts. Now powered by Stellar blockchain for transparency and security."
+    },
+    "howItWorks": {
+      "title": "How It Works",
+      "step1": {
+        "title": "Join or Create a Group",
+        "description": "Start your own savings group or join an existing one with friends, family, or community members."
+      },
+      "step2": {
+        "title": "Contribute Regularly",
+        "description": "Each member contributes a fixed amount every cycle. All contributions are recorded on the blockchain."
+      },
+      "step3": {
+        "title": "Receive Your Payout",
+        "description": "Members take turns receiving the full pool. Everyone gets their turn until the cycle completes."
+      }
+    }
+  },
+  "wallet": {
+    "connect": "Connect Wallet",
+    "disconnect": "Disconnect",
+    "connecting": "Connecting...",
+    "connected": "Connected",
+    "notConnected": "Not Connected",
+    "balance": "Balance",
+    "address": "Address",
+    "copyAddress": "Copy Address",
+    "addressCopied": "Address copied!",
+    "installFreighter": "Install Freighter Wallet",
+    "freighterRequired": "Freighter wallet is required to use this app"
+  },
+  "group": {
+    "create": "Create Group",
+    "join": "Join Group",
+    "leave": "Leave Group",
+    "details": "Group Details",
+    "members": "Members",
+    "status": "Status",
+    "active": "Active",
+    "complete": "Complete",
+    "cancelled": "Cancelled",
+    "contributionAmount": "Contribution Amount",
+    "cycleDuration": "Cycle Duration",
+    "maxMembers": "Max Members",
+    "currentCycle": "Current Cycle",
+    "nextRecipient": "Next Recipient",
+    "contributionsReceived": "Contributions Received",
+    "pendingContributors": "Pending Contributors",
+    "cycleStartTime": "Cycle Start Time",
+    "cycleEndTime": "Cycle End Time",
+    "createdAt": "Created At",
+    "creator": "Creator",
+    "myGroups": "My Groups",
+    "allGroups": "All Groups",
+    "noGroups": "No groups found",
+    "createFirst": "Create your first group to get started"
+  },
+  "groupForm": {
+    "title": "Create New Group",
+    "name": "Group Name",
+    "namePlaceholder": "Enter group name",
+    "description": "Description",
+    "descriptionPlaceholder": "Describe the purpose of this group",
+    "rules": "Rules",
+    "rulesPlaceholder": "Set group rules and guidelines",
+    "contributionAmount": "Contribution Amount (XLM)",
+    "contributionAmountPlaceholder": "Amount each member contributes",
+    "cycleDuration": "Cycle Duration (days)",
+    "cycleDurationPlaceholder": "How long each cycle lasts",
+    "maxMembers": "Maximum Members",
+    "maxMembersPlaceholder": "Maximum number of members (2-100)",
+    "creating": "Creating...",
+    "create": "Create Group"
+  },
+  "contribution": {
+    "make": "Make Contribution",
+    "amount": "Amount",
+    "contribute": "Contribute",
+    "contributing": "Contributing...",
+    "success": "Contribution successful!",
+    "alreadyContributed": "You have already contributed this cycle",
+    "notMember": "You are not a member of this group",
+    "cycleComplete": "This cycle is complete",
+    "history": "Contribution History"
+  },
+  "transaction": {
+    "history": "Transaction History",
+    "type": "Type",
+    "amount": "Amount",
+    "date": "Date",
+    "status": "Status",
+    "pending": "Pending",
+    "confirmed": "Confirmed",
+    "failed": "Failed",
+    "contribution": "Contribution",
+    "payout": "Payout",
+    "noTransactions": "No transactions yet"
+  },
+  "profile": {
+    "title": "Profile",
+    "settings": "Profile Settings",
+    "displayName": "Display Name",
+    "email": "Email",
+    "bio": "Bio",
+    "language": "Language",
+    "theme": "Theme",
+    "notifications": "Notifications",
+    "save": "Save Changes",
+    "saving": "Saving..."
+  },
+  "analytics": {
+    "title": "Analytics",
+    "totalGroups": "Total Groups",
+    "totalMembers": "Total Members",
+    "totalContributions": "Total Contributions",
+    "totalPayouts": "Total Payouts",
+    "activeGroups": "Active Groups",
+    "completedGroups": "Completed Groups"
+  },
+  "language": {
+    "select": "Select Language",
+    "en": "English",
+    "es": "Español",
+    "fr": "Français",
+    "pt": "Português",
+    "sw": "Kiswahili"
+  },
+  "errors": {
+    "generic": "Something went wrong",
+    "networkError": "Network error. Please check your connection.",
+    "walletNotConnected": "Please connect your wallet",
+    "insufficientBalance": "Insufficient balance",
+    "transactionFailed": "Transaction failed",
+    "groupNotFound": "Group not found",
+    "unauthorized": "Unauthorized",
+    "invalidInput": "Invalid input",
+    "maxMembersExceeded": "Maximum members exceeded",
+    "alreadyMember": "Already a member",
+    "notMember": "Not a member",
+    "alreadyContributed": "Already contributed this cycle",
+    "groupComplete": "Group is complete",
+    "contractPaused": "Contract is paused"
+  },
+  "time": {
+    "seconds": "seconds",
+    "minutes": "minutes",
+    "hours": "hours",
+    "days": "days",
+    "weeks": "weeks",
+    "months": "months",
+    "years": "years",
+    "ago": "ago",
+    "remaining": "remaining"
+  }
+}

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -1,0 +1,190 @@
+{
+  "common": {
+    "appName": "Ajo",
+    "loading": "Cargando...",
+    "error": "Error",
+    "success": "Éxito",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "close": "Cerrar",
+    "back": "Atrás",
+    "next": "Siguiente",
+    "submit": "Enviar",
+    "search": "Buscar",
+    "filter": "Filtrar",
+    "clear": "Limpiar",
+    "viewDetails": "Ver Detalles",
+    "learnMore": "Saber Más",
+    "getStarted": "Comenzar"
+  },
+  "nav": {
+    "home": "Inicio",
+    "dashboard": "Panel",
+    "groups": "Grupos",
+    "profile": "Perfil",
+    "analytics": "Analíticas",
+    "community": "Comunidad",
+    "settings": "Configuración"
+  },
+  "home": {
+    "hero": {
+      "title": "Ahorra juntos. Crece juntos.",
+      "subtitle": "Ahorros tradicionales, confianza blockchain",
+      "description": "Ajo es un sistema de ahorro comunitario donde los grupos contribuyen juntos y se turnan para recibir pagos. Ahora impulsado por blockchain Stellar para transparencia y seguridad."
+    },
+    "howItWorks": {
+      "title": "Cómo Funciona",
+      "step1": {
+        "title": "Únete o Crea un Grupo",
+        "description": "Inicia tu propio grupo de ahorro o únete a uno existente con amigos, familia o miembros de la comunidad."
+      },
+      "step2": {
+        "title": "Contribuye Regularmente",
+        "description": "Cada miembro contribuye una cantidad fija en cada ciclo. Todas las contribuciones se registran en blockchain."
+      },
+      "step3": {
+        "title": "Recibe tu Pago",
+        "description": "Los miembros se turnan para recibir el fondo completo. Todos tienen su turno hasta que el ciclo se completa."
+      }
+    }
+  },
+  "wallet": {
+    "connect": "Conectar Billetera",
+    "disconnect": "Desconectar",
+    "connecting": "Conectando...",
+    "connected": "Conectado",
+    "notConnected": "No Conectado",
+    "balance": "Saldo",
+    "address": "Dirección",
+    "copyAddress": "Copiar Dirección",
+    "addressCopied": "¡Dirección copiada!",
+    "installFreighter": "Instalar Billetera Freighter",
+    "freighterRequired": "Se requiere la billetera Freighter para usar esta aplicación"
+  },
+  "group": {
+    "create": "Crear Grupo",
+    "join": "Unirse al Grupo",
+    "leave": "Salir del Grupo",
+    "details": "Detalles del Grupo",
+    "members": "Miembros",
+    "status": "Estado",
+    "active": "Activo",
+    "complete": "Completo",
+    "cancelled": "Cancelado",
+    "contributionAmount": "Monto de Contribución",
+    "cycleDuration": "Duración del Ciclo",
+    "maxMembers": "Máximo de Miembros",
+    "currentCycle": "Ciclo Actual",
+    "nextRecipient": "Próximo Receptor",
+    "contributionsReceived": "Contribuciones Recibidas",
+    "pendingContributors": "Contribuyentes Pendientes",
+    "cycleStartTime": "Hora de Inicio del Ciclo",
+    "cycleEndTime": "Hora de Fin del Ciclo",
+    "createdAt": "Creado el",
+    "creator": "Creador",
+    "myGroups": "Mis Grupos",
+    "allGroups": "Todos los Grupos",
+    "noGroups": "No se encontraron grupos",
+    "createFirst": "Crea tu primer grupo para comenzar"
+  },
+  "groupForm": {
+    "title": "Crear Nuevo Grupo",
+    "name": "Nombre del Grupo",
+    "namePlaceholder": "Ingresa el nombre del grupo",
+    "description": "Descripción",
+    "descriptionPlaceholder": "Describe el propósito de este grupo",
+    "rules": "Reglas",
+    "rulesPlaceholder": "Establece reglas y pautas del grupo",
+    "contributionAmount": "Monto de Contribución (XLM)",
+    "contributionAmountPlaceholder": "Cantidad que contribuye cada miembro",
+    "cycleDuration": "Duración del Ciclo (días)",
+    "cycleDurationPlaceholder": "Cuánto dura cada ciclo",
+    "maxMembers": "Máximo de Miembros",
+    "maxMembersPlaceholder": "Número máximo de miembros (2-100)",
+    "creating": "Creando...",
+    "create": "Crear Grupo"
+  },
+  "contribution": {
+    "make": "Hacer Contribución",
+    "amount": "Cantidad",
+    "contribute": "Contribuir",
+    "contributing": "Contribuyendo...",
+    "success": "¡Contribución exitosa!",
+    "alreadyContributed": "Ya has contribuido en este ciclo",
+    "notMember": "No eres miembro de este grupo",
+    "cycleComplete": "Este ciclo está completo",
+    "history": "Historial de Contribuciones"
+  },
+  "transaction": {
+    "history": "Historial de Transacciones",
+    "type": "Tipo",
+    "amount": "Cantidad",
+    "date": "Fecha",
+    "status": "Estado",
+    "pending": "Pendiente",
+    "confirmed": "Confirmado",
+    "failed": "Fallido",
+    "contribution": "Contribución",
+    "payout": "Pago",
+    "noTransactions": "Aún no hay transacciones"
+  },
+  "profile": {
+    "title": "Perfil",
+    "settings": "Configuración del Perfil",
+    "displayName": "Nombre para Mostrar",
+    "email": "Correo Electrónico",
+    "bio": "Biografía",
+    "language": "Idioma",
+    "theme": "Tema",
+    "notifications": "Notificaciones",
+    "save": "Guardar Cambios",
+    "saving": "Guardando..."
+  },
+  "analytics": {
+    "title": "Analíticas",
+    "totalGroups": "Total de Grupos",
+    "totalMembers": "Total de Miembros",
+    "totalContributions": "Total de Contribuciones",
+    "totalPayouts": "Total de Pagos",
+    "activeGroups": "Grupos Activos",
+    "completedGroups": "Grupos Completados"
+  },
+  "language": {
+    "select": "Seleccionar Idioma",
+    "en": "English",
+    "es": "Español",
+    "fr": "Français",
+    "pt": "Português",
+    "sw": "Kiswahili"
+  },
+  "errors": {
+    "generic": "Algo salió mal",
+    "networkError": "Error de red. Por favor verifica tu conexión.",
+    "walletNotConnected": "Por favor conecta tu billetera",
+    "insufficientBalance": "Saldo insuficiente",
+    "transactionFailed": "Transacción fallida",
+    "groupNotFound": "Grupo no encontrado",
+    "unauthorized": "No autorizado",
+    "invalidInput": "Entrada inválida",
+    "maxMembersExceeded": "Máximo de miembros excedido",
+    "alreadyMember": "Ya eres miembro",
+    "notMember": "No eres miembro",
+    "alreadyContributed": "Ya contribuiste en este ciclo",
+    "groupComplete": "El grupo está completo",
+    "contractPaused": "El contrato está pausado"
+  },
+  "time": {
+    "seconds": "segundos",
+    "minutes": "minutos",
+    "hours": "horas",
+    "days": "días",
+    "weeks": "semanas",
+    "months": "meses",
+    "years": "años",
+    "ago": "hace",
+    "remaining": "restante"
+  }
+}

--- a/frontend/src/locales/fr.json
+++ b/frontend/src/locales/fr.json
@@ -1,0 +1,190 @@
+{
+  "common": {
+    "appName": "Ajo",
+    "loading": "Chargement...",
+    "error": "Erreur",
+    "success": "Succès",
+    "cancel": "Annuler",
+    "confirm": "Confirmer",
+    "save": "Enregistrer",
+    "delete": "Supprimer",
+    "edit": "Modifier",
+    "close": "Fermer",
+    "back": "Retour",
+    "next": "Suivant",
+    "submit": "Soumettre",
+    "search": "Rechercher",
+    "filter": "Filtrer",
+    "clear": "Effacer",
+    "viewDetails": "Voir les Détails",
+    "learnMore": "En Savoir Plus",
+    "getStarted": "Commencer"
+  },
+  "nav": {
+    "home": "Accueil",
+    "dashboard": "Tableau de Bord",
+    "groups": "Groupes",
+    "profile": "Profil",
+    "analytics": "Analytiques",
+    "community": "Communauté",
+    "settings": "Paramètres"
+  },
+  "home": {
+    "hero": {
+      "title": "Économisez ensemble. Grandissez ensemble.",
+      "subtitle": "Épargne traditionnelle, confiance blockchain",
+      "description": "Ajo est un système d'épargne communautaire où les groupes contribuent ensemble et reçoivent des paiements à tour de rôle. Maintenant alimenté par la blockchain Stellar pour la transparence et la sécurité."
+    },
+    "howItWorks": {
+      "title": "Comment Ça Marche",
+      "step1": {
+        "title": "Rejoindre ou Créer un Groupe",
+        "description": "Créez votre propre groupe d'épargne ou rejoignez-en un existant avec des amis, de la famille ou des membres de la communauté."
+      },
+      "step2": {
+        "title": "Contribuer Régulièrement",
+        "description": "Chaque membre contribue un montant fixe à chaque cycle. Toutes les contributions sont enregistrées sur la blockchain."
+      },
+      "step3": {
+        "title": "Recevoir Votre Paiement",
+        "description": "Les membres reçoivent à tour de rôle le fonds complet. Tout le monde a son tour jusqu'à ce que le cycle soit terminé."
+      }
+    }
+  },
+  "wallet": {
+    "connect": "Connecter le Portefeuille",
+    "disconnect": "Déconnecter",
+    "connecting": "Connexion...",
+    "connected": "Connecté",
+    "notConnected": "Non Connecté",
+    "balance": "Solde",
+    "address": "Adresse",
+    "copyAddress": "Copier l'Adresse",
+    "addressCopied": "Adresse copiée!",
+    "installFreighter": "Installer le Portefeuille Freighter",
+    "freighterRequired": "Le portefeuille Freighter est requis pour utiliser cette application"
+  },
+  "group": {
+    "create": "Créer un Groupe",
+    "join": "Rejoindre le Groupe",
+    "leave": "Quitter le Groupe",
+    "details": "Détails du Groupe",
+    "members": "Membres",
+    "status": "Statut",
+    "active": "Actif",
+    "complete": "Terminé",
+    "cancelled": "Annulé",
+    "contributionAmount": "Montant de Contribution",
+    "cycleDuration": "Durée du Cycle",
+    "maxMembers": "Membres Maximum",
+    "currentCycle": "Cycle Actuel",
+    "nextRecipient": "Prochain Bénéficiaire",
+    "contributionsReceived": "Contributions Reçues",
+    "pendingContributors": "Contributeurs en Attente",
+    "cycleStartTime": "Heure de Début du Cycle",
+    "cycleEndTime": "Heure de Fin du Cycle",
+    "createdAt": "Créé le",
+    "creator": "Créateur",
+    "myGroups": "Mes Groupes",
+    "allGroups": "Tous les Groupes",
+    "noGroups": "Aucun groupe trouvé",
+    "createFirst": "Créez votre premier groupe pour commencer"
+  },
+  "groupForm": {
+    "title": "Créer un Nouveau Groupe",
+    "name": "Nom du Groupe",
+    "namePlaceholder": "Entrez le nom du groupe",
+    "description": "Description",
+    "descriptionPlaceholder": "Décrivez l'objectif de ce groupe",
+    "rules": "Règles",
+    "rulesPlaceholder": "Définir les règles et directives du groupe",
+    "contributionAmount": "Montant de Contribution (XLM)",
+    "contributionAmountPlaceholder": "Montant que chaque membre contribue",
+    "cycleDuration": "Durée du Cycle (jours)",
+    "cycleDurationPlaceholder": "Combien de temps dure chaque cycle",
+    "maxMembers": "Membres Maximum",
+    "maxMembersPlaceholder": "Nombre maximum de membres (2-100)",
+    "creating": "Création...",
+    "create": "Créer un Groupe"
+  },
+  "contribution": {
+    "make": "Faire une Contribution",
+    "amount": "Montant",
+    "contribute": "Contribuer",
+    "contributing": "Contribution...",
+    "success": "Contribution réussie!",
+    "alreadyContributed": "Vous avez déjà contribué ce cycle",
+    "notMember": "Vous n'êtes pas membre de ce groupe",
+    "cycleComplete": "Ce cycle est terminé",
+    "history": "Historique des Contributions"
+  },
+  "transaction": {
+    "history": "Historique des Transactions",
+    "type": "Type",
+    "amount": "Montant",
+    "date": "Date",
+    "status": "Statut",
+    "pending": "En Attente",
+    "confirmed": "Confirmé",
+    "failed": "Échoué",
+    "contribution": "Contribution",
+    "payout": "Paiement",
+    "noTransactions": "Aucune transaction pour le moment"
+  },
+  "profile": {
+    "title": "Profil",
+    "settings": "Paramètres du Profil",
+    "displayName": "Nom d'Affichage",
+    "email": "Email",
+    "bio": "Biographie",
+    "language": "Langue",
+    "theme": "Thème",
+    "notifications": "Notifications",
+    "save": "Enregistrer les Modifications",
+    "saving": "Enregistrement..."
+  },
+  "analytics": {
+    "title": "Analytiques",
+    "totalGroups": "Total des Groupes",
+    "totalMembers": "Total des Membres",
+    "totalContributions": "Total des Contributions",
+    "totalPayouts": "Total des Paiements",
+    "activeGroups": "Groupes Actifs",
+    "completedGroups": "Groupes Terminés"
+  },
+  "language": {
+    "select": "Sélectionner la Langue",
+    "en": "English",
+    "es": "Español",
+    "fr": "Français",
+    "pt": "Português",
+    "sw": "Kiswahili"
+  },
+  "errors": {
+    "generic": "Quelque chose s'est mal passé",
+    "networkError": "Erreur réseau. Veuillez vérifier votre connexion.",
+    "walletNotConnected": "Veuillez connecter votre portefeuille",
+    "insufficientBalance": "Solde insuffisant",
+    "transactionFailed": "Transaction échouée",
+    "groupNotFound": "Groupe non trouvé",
+    "unauthorized": "Non autorisé",
+    "invalidInput": "Entrée invalide",
+    "maxMembersExceeded": "Nombre maximum de membres dépassé",
+    "alreadyMember": "Déjà membre",
+    "notMember": "Pas membre",
+    "alreadyContributed": "Déjà contribué ce cycle",
+    "groupComplete": "Le groupe est terminé",
+    "contractPaused": "Le contrat est en pause"
+  },
+  "time": {
+    "seconds": "secondes",
+    "minutes": "minutes",
+    "hours": "heures",
+    "days": "jours",
+    "weeks": "semaines",
+    "months": "mois",
+    "years": "années",
+    "ago": "il y a",
+    "remaining": "restant"
+  }
+}

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -1,0 +1,190 @@
+{
+  "common": {
+    "appName": "Ajo",
+    "loading": "Carregando...",
+    "error": "Erro",
+    "success": "Sucesso",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "save": "Salvar",
+    "delete": "Excluir",
+    "edit": "Editar",
+    "close": "Fechar",
+    "back": "Voltar",
+    "next": "Próximo",
+    "submit": "Enviar",
+    "search": "Pesquisar",
+    "filter": "Filtrar",
+    "clear": "Limpar",
+    "viewDetails": "Ver Detalhes",
+    "learnMore": "Saiba Mais",
+    "getStarted": "Começar"
+  },
+  "nav": {
+    "home": "Início",
+    "dashboard": "Painel",
+    "groups": "Grupos",
+    "profile": "Perfil",
+    "analytics": "Análises",
+    "community": "Comunidade",
+    "settings": "Configurações"
+  },
+  "home": {
+    "hero": {
+      "title": "Economize juntos. Cresça juntos.",
+      "subtitle": "Poupança tradicional, confiança blockchain",
+      "description": "Ajo é um sistema de poupança comunitário onde grupos contribuem juntos e recebem pagamentos alternadamente. Agora alimentado pela blockchain Stellar para transparência e segurança."
+    },
+    "howItWorks": {
+      "title": "Como Funciona",
+      "step1": {
+        "title": "Junte-se ou Crie um Grupo",
+        "description": "Inicie seu próprio grupo de poupança ou junte-se a um existente com amigos, família ou membros da comunidade."
+      },
+      "step2": {
+        "title": "Contribua Regularmente",
+        "description": "Cada membro contribui com um valor fixo a cada ciclo. Todas as contribuições são registradas na blockchain."
+      },
+      "step3": {
+        "title": "Receba Seu Pagamento",
+        "description": "Os membros se revezam para receber o fundo completo. Todos têm sua vez até que o ciclo seja concluído."
+      }
+    }
+  },
+  "wallet": {
+    "connect": "Conectar Carteira",
+    "disconnect": "Desconectar",
+    "connecting": "Conectando...",
+    "connected": "Conectado",
+    "notConnected": "Não Conectado",
+    "balance": "Saldo",
+    "address": "Endereço",
+    "copyAddress": "Copiar Endereço",
+    "addressCopied": "Endereço copiado!",
+    "installFreighter": "Instalar Carteira Freighter",
+    "freighterRequired": "A carteira Freighter é necessária para usar este aplicativo"
+  },
+  "group": {
+    "create": "Criar Grupo",
+    "join": "Entrar no Grupo",
+    "leave": "Sair do Grupo",
+    "details": "Detalhes do Grupo",
+    "members": "Membros",
+    "status": "Status",
+    "active": "Ativo",
+    "complete": "Completo",
+    "cancelled": "Cancelado",
+    "contributionAmount": "Valor da Contribuição",
+    "cycleDuration": "Duração do Ciclo",
+    "maxMembers": "Máximo de Membros",
+    "currentCycle": "Ciclo Atual",
+    "nextRecipient": "Próximo Destinatário",
+    "contributionsReceived": "Contribuições Recebidas",
+    "pendingContributors": "Contribuintes Pendentes",
+    "cycleStartTime": "Hora de Início do Ciclo",
+    "cycleEndTime": "Hora de Término do Ciclo",
+    "createdAt": "Criado em",
+    "creator": "Criador",
+    "myGroups": "Meus Grupos",
+    "allGroups": "Todos os Grupos",
+    "noGroups": "Nenhum grupo encontrado",
+    "createFirst": "Crie seu primeiro grupo para começar"
+  },
+  "groupForm": {
+    "title": "Criar Novo Grupo",
+    "name": "Nome do Grupo",
+    "namePlaceholder": "Digite o nome do grupo",
+    "description": "Descrição",
+    "descriptionPlaceholder": "Descreva o propósito deste grupo",
+    "rules": "Regras",
+    "rulesPlaceholder": "Defina regras e diretrizes do grupo",
+    "contributionAmount": "Valor da Contribuição (XLM)",
+    "contributionAmountPlaceholder": "Valor que cada membro contribui",
+    "cycleDuration": "Duração do Ciclo (dias)",
+    "cycleDurationPlaceholder": "Quanto tempo dura cada ciclo",
+    "maxMembers": "Máximo de Membros",
+    "maxMembersPlaceholder": "Número máximo de membros (2-100)",
+    "creating": "Criando...",
+    "create": "Criar Grupo"
+  },
+  "contribution": {
+    "make": "Fazer Contribuição",
+    "amount": "Valor",
+    "contribute": "Contribuir",
+    "contributing": "Contribuindo...",
+    "success": "Contribuição bem-sucedida!",
+    "alreadyContributed": "Você já contribuiu neste ciclo",
+    "notMember": "Você não é membro deste grupo",
+    "cycleComplete": "Este ciclo está completo",
+    "history": "Histórico de Contribuições"
+  },
+  "transaction": {
+    "history": "Histórico de Transações",
+    "type": "Tipo",
+    "amount": "Valor",
+    "date": "Data",
+    "status": "Status",
+    "pending": "Pendente",
+    "confirmed": "Confirmado",
+    "failed": "Falhou",
+    "contribution": "Contribuição",
+    "payout": "Pagamento",
+    "noTransactions": "Ainda não há transações"
+  },
+  "profile": {
+    "title": "Perfil",
+    "settings": "Configurações do Perfil",
+    "displayName": "Nome de Exibição",
+    "email": "Email",
+    "bio": "Biografia",
+    "language": "Idioma",
+    "theme": "Tema",
+    "notifications": "Notificações",
+    "save": "Salvar Alterações",
+    "saving": "Salvando..."
+  },
+  "analytics": {
+    "title": "Análises",
+    "totalGroups": "Total de Grupos",
+    "totalMembers": "Total de Membros",
+    "totalContributions": "Total de Contribuições",
+    "totalPayouts": "Total de Pagamentos",
+    "activeGroups": "Grupos Ativos",
+    "completedGroups": "Grupos Concluídos"
+  },
+  "language": {
+    "select": "Selecionar Idioma",
+    "en": "English",
+    "es": "Español",
+    "fr": "Français",
+    "pt": "Português",
+    "sw": "Kiswahili"
+  },
+  "errors": {
+    "generic": "Algo deu errado",
+    "networkError": "Erro de rede. Por favor, verifique sua conexão.",
+    "walletNotConnected": "Por favor, conecte sua carteira",
+    "insufficientBalance": "Saldo insuficiente",
+    "transactionFailed": "Transação falhou",
+    "groupNotFound": "Grupo não encontrado",
+    "unauthorized": "Não autorizado",
+    "invalidInput": "Entrada inválida",
+    "maxMembersExceeded": "Máximo de membros excedido",
+    "alreadyMember": "Já é membro",
+    "notMember": "Não é membro",
+    "alreadyContributed": "Já contribuiu neste ciclo",
+    "groupComplete": "O grupo está completo",
+    "contractPaused": "O contrato está pausado"
+  },
+  "time": {
+    "seconds": "segundos",
+    "minutes": "minutos",
+    "hours": "horas",
+    "days": "dias",
+    "weeks": "semanas",
+    "months": "meses",
+    "years": "anos",
+    "ago": "atrás",
+    "remaining": "restante"
+  }
+}

--- a/frontend/src/locales/sw.json
+++ b/frontend/src/locales/sw.json
@@ -1,0 +1,190 @@
+{
+  "common": {
+    "appName": "Ajo",
+    "loading": "Inapakia...",
+    "error": "Hitilafu",
+    "success": "Mafanikio",
+    "cancel": "Ghairi",
+    "confirm": "Thibitisha",
+    "save": "Hifadhi",
+    "delete": "Futa",
+    "edit": "Hariri",
+    "close": "Funga",
+    "back": "Rudi",
+    "next": "Ifuatayo",
+    "submit": "Wasilisha",
+    "search": "Tafuta",
+    "filter": "Chuja",
+    "clear": "Futa",
+    "viewDetails": "Tazama Maelezo",
+    "learnMore": "Jifunze Zaidi",
+    "getStarted": "Anza"
+  },
+  "nav": {
+    "home": "Nyumbani",
+    "dashboard": "Dashibodi",
+    "groups": "Vikundi",
+    "profile": "Wasifu",
+    "analytics": "Takwimu",
+    "community": "Jamii",
+    "settings": "Mipangilio"
+  },
+  "home": {
+    "hero": {
+      "title": "Okoa pamoja. Kua pamoja.",
+      "subtitle": "Akiba za jadi, uaminifu wa blockchain",
+      "description": "Ajo ni mfumo wa akiba wa jamii ambapo vikundi vinachangia pamoja na kupokea malipo kwa zamu. Sasa inasaidiwa na blockchain ya Stellar kwa uwazi na usalama."
+    },
+    "howItWorks": {
+      "title": "Jinsi Inavyofanya Kazi",
+      "step1": {
+        "title": "Jiunge au Unda Kikundi",
+        "description": "Anzisha kikundi chako cha akiba au jiunge na kilichopo na marafiki, familia, au wanajamii."
+      },
+      "step2": {
+        "title": "Changia Mara kwa Mara",
+        "description": "Kila mwanachama anachangia kiasi kilichowekwa kila mzunguko. Michango yote inarekodiwa kwenye blockchain."
+      },
+      "step3": {
+        "title": "Pokea Malipo Yako",
+        "description": "Wanachama wanapokea mfuko kamili kwa zamu. Kila mtu anapata zamu yake hadi mzunguko ukamilike."
+      }
+    }
+  },
+  "wallet": {
+    "connect": "Unganisha Mkoba",
+    "disconnect": "Tenganisha",
+    "connecting": "Inaunganisha...",
+    "connected": "Imeunganishwa",
+    "notConnected": "Haijaunganishwa",
+    "balance": "Salio",
+    "address": "Anwani",
+    "copyAddress": "Nakili Anwani",
+    "addressCopied": "Anwani imenakiliwa!",
+    "installFreighter": "Sakinisha Mkoba wa Freighter",
+    "freighterRequired": "Mkoba wa Freighter unahitajika kutumia programu hii"
+  },
+  "group": {
+    "create": "Unda Kikundi",
+    "join": "Jiunge na Kikundi",
+    "leave": "Acha Kikundi",
+    "details": "Maelezo ya Kikundi",
+    "members": "Wanachama",
+    "status": "Hali",
+    "active": "Hai",
+    "complete": "Kamili",
+    "cancelled": "Imeghairiwa",
+    "contributionAmount": "Kiasi cha Mchango",
+    "cycleDuration": "Muda wa Mzunguko",
+    "maxMembers": "Wanachama Wengi Zaidi",
+    "currentCycle": "Mzunguko wa Sasa",
+    "nextRecipient": "Mpokeaji Anayefuata",
+    "contributionsReceived": "Michango Iliyopokelewa",
+    "pendingContributors": "Wachangiaji Wanaosubiri",
+    "cycleStartTime": "Muda wa Kuanza Mzunguko",
+    "cycleEndTime": "Muda wa Kumalizika Mzunguko",
+    "createdAt": "Iliundwa",
+    "creator": "Muundaji",
+    "myGroups": "Vikundi Vyangu",
+    "allGroups": "Vikundi Vyote",
+    "noGroups": "Hakuna vikundi vilivyopatikana",
+    "createFirst": "Unda kikundi chako cha kwanza kuanza"
+  },
+  "groupForm": {
+    "title": "Unda Kikundi Kipya",
+    "name": "Jina la Kikundi",
+    "namePlaceholder": "Ingiza jina la kikundi",
+    "description": "Maelezo",
+    "descriptionPlaceholder": "Eleza madhumuni ya kikundi hiki",
+    "rules": "Sheria",
+    "rulesPlaceholder": "Weka sheria na miongozo ya kikundi",
+    "contributionAmount": "Kiasi cha Mchango (XLM)",
+    "contributionAmountPlaceholder": "Kiasi kinachochangiwa na kila mwanachama",
+    "cycleDuration": "Muda wa Mzunguko (siku)",
+    "cycleDurationPlaceholder": "Muda gani kila mzunguko unachukua",
+    "maxMembers": "Wanachama Wengi Zaidi",
+    "maxMembersPlaceholder": "Idadi ya juu ya wanachama (2-100)",
+    "creating": "Inaunda...",
+    "create": "Unda Kikundi"
+  },
+  "contribution": {
+    "make": "Fanya Mchango",
+    "amount": "Kiasi",
+    "contribute": "Changia",
+    "contributing": "Inachangia...",
+    "success": "Mchango umefanikiwa!",
+    "alreadyContributed": "Tayari umechangia mzunguko huu",
+    "notMember": "Wewe si mwanachama wa kikundi hiki",
+    "cycleComplete": "Mzunguko huu umekamilika",
+    "history": "Historia ya Michango"
+  },
+  "transaction": {
+    "history": "Historia ya Miamala",
+    "type": "Aina",
+    "amount": "Kiasi",
+    "date": "Tarehe",
+    "status": "Hali",
+    "pending": "Inasubiri",
+    "confirmed": "Imethibitishwa",
+    "failed": "Imeshindwa",
+    "contribution": "Mchango",
+    "payout": "Malipo",
+    "noTransactions": "Bado hakuna miamala"
+  },
+  "profile": {
+    "title": "Wasifu",
+    "settings": "Mipangilio ya Wasifu",
+    "displayName": "Jina la Kuonyesha",
+    "email": "Barua Pepe",
+    "bio": "Wasifu",
+    "language": "Lugha",
+    "theme": "Mandhari",
+    "notifications": "Arifa",
+    "save": "Hifadhi Mabadiliko",
+    "saving": "Inahifadhi..."
+  },
+  "analytics": {
+    "title": "Takwimu",
+    "totalGroups": "Jumla ya Vikundi",
+    "totalMembers": "Jumla ya Wanachama",
+    "totalContributions": "Jumla ya Michango",
+    "totalPayouts": "Jumla ya Malipo",
+    "activeGroups": "Vikundi Hai",
+    "completedGroups": "Vikundi Vilivyokamilika"
+  },
+  "language": {
+    "select": "Chagua Lugha",
+    "en": "English",
+    "es": "Español",
+    "fr": "Français",
+    "pt": "Português",
+    "sw": "Kiswahili"
+  },
+  "errors": {
+    "generic": "Kuna kitu kimeenda vibaya",
+    "networkError": "Hitilafu ya mtandao. Tafadhali angalia muunganisho wako.",
+    "walletNotConnected": "Tafadhali unganisha mkoba wako",
+    "insufficientBalance": "Salio haitoshi",
+    "transactionFailed": "Muamala umeshindwa",
+    "groupNotFound": "Kikundi hakijapatikana",
+    "unauthorized": "Hauruhusiwi",
+    "invalidInput": "Ingizo batili",
+    "maxMembersExceeded": "Idadi ya juu ya wanachama imezidishwa",
+    "alreadyMember": "Tayari ni mwanachama",
+    "notMember": "Si mwanachama",
+    "alreadyContributed": "Tayari umechangia mzunguko huu",
+    "groupComplete": "Kikundi kimekamilika",
+    "contractPaused": "Mkataba umesimamishwa"
+  },
+  "time": {
+    "seconds": "sekunde",
+    "minutes": "dakika",
+    "hours": "saa",
+    "days": "siku",
+    "weeks": "wiki",
+    "months": "miezi",
+    "years": "miaka",
+    "ago": "iliyopita",
+    "remaining": "iliyobaki"
+  }
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,12 @@
+import createMiddleware from 'next-intl/middleware';
+import { locales } from './i18n';
+
+export default createMiddleware({
+  locales,
+  defaultLocale: 'en',
+  localePrefix: 'always'
+});
+
+export const config = {
+  matcher: ['/((?!api|_next|_vercel|.*\\..*).*)']
+};

--- a/frontend/src/utils/i18n/formatters.ts
+++ b/frontend/src/utils/i18n/formatters.ts
@@ -1,0 +1,54 @@
+export function formatCurrency(amount: number, locale: string = 'en'): string {
+  const formatter = new Intl.NumberFormat(locale, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 7,
+  });
+  return `${formatter.format(amount)} XLM`;
+}
+
+export function formatDate(date: Date | number, locale: string = 'en', options?: Intl.DateTimeFormatOptions): string {
+  const defaultOptions: Intl.DateTimeFormatOptions = {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    ...options
+  };
+  return new Intl.DateTimeFormat(locale, defaultOptions).format(date);
+}
+
+export function formatDateTime(date: Date | number, locale: string = 'en'): string {
+  return new Intl.DateTimeFormat(locale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+export function formatRelativeTime(date: Date | number, locale: string = 'en'): string {
+  const now = Date.now();
+  const timestamp = typeof date === 'number' ? date : date.getTime();
+  const diff = now - timestamp;
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  const weeks = Math.floor(days / 7);
+  const months = Math.floor(days / 30);
+  const years = Math.floor(days / 365);
+
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+
+  if (years > 0) return rtf.format(-years, 'year');
+  if (months > 0) return rtf.format(-months, 'month');
+  if (weeks > 0) return rtf.format(-weeks, 'week');
+  if (days > 0) return rtf.format(-days, 'day');
+  if (hours > 0) return rtf.format(-hours, 'hour');
+  if (minutes > 0) return rtf.format(-minutes, 'minute');
+  return rtf.format(-seconds, 'second');
+}
+
+export function formatNumber(value: number, locale: string = 'en', options?: Intl.NumberFormatOptions): string {
+  return new Intl.NumberFormat(locale, options).format(value);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,6 +117,7 @@
         "framer-motion": "^11.18.2",
         "lucide-react": "^0.575.0",
         "next": "^14.1.0",
+        "next-intl": "^4.8.3",
         "next-themes": "^0.4.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -2898,6 +2899,58 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.1.1.tgz",
+      "integrity": "sha512-jhZbTwda+2tcNrs4kKvxrPLPjx8QsBCLCUgrrJ/S+G9YrGHWLhAyFMMBHJBnBoOwuLHd7L14FgYudviKaxkO2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.0",
+        "@formatjs/intl-localematcher": "0.8.1",
+        "decimal.js": "^10.6.0",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.0.tgz",
+      "integrity": "sha512-b5mvSWCI+XVKiz5WhnBCY3RJ4ZwfjAidU0yVlKa3d3MSgKmH1hC3tBGEAtYyN5mqL7N0G5x0BOUYyO8CEupWgg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.1.tgz",
+      "integrity": "sha512-sSDmSvmmoVQ92XqWb499KrIhv/vLisJU8ITFrx7T7NZHUmMY7EL9xgRowAosaljhqnj/5iufG24QrdzB6X3ItA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.1.1",
+        "@formatjs/icu-skeleton-parser": "2.1.1",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.1.tgz",
+      "integrity": "sha512-PSFABlcNefjI6yyk8f7nyX1DC7NHmq6WaCHZLySEXBrXuLOB2f935YsnzuPjlz+ibhb9yWTdPeVX1OVcj24w2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.1.1",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.1.tgz",
+      "integrity": "sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.0",
+        "tslib": "^2.8.1"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -4208,6 +4261,313 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4663,6 +5023,12 @@
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
@@ -6134,6 +6500,166 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.13.tgz",
+      "integrity": "sha512-ztXusRuC5NV2w+a6pDhX13CGioMLq8CjX5P4XgVJ21ocqz9t19288Do0y8LklplDtwcEhYGTNdMbkmUT7+lDTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.13.tgz",
+      "integrity": "sha512-cVifxQUKhaE7qcO/y9Mq6PEhoyvN9tSLzCnnFZ4EIabFHBuLtDDO6a+vLveOy98hAs5Qu1+bb5Nv0oa1Pihe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.13.tgz",
+      "integrity": "sha512-t+xxEzZ48enl/wGGy7SRYd7kImWQ/+wvVFD7g5JZo234g6/QnIgZ+YdfIyjHB+ZJI3F7a2IQHS7RNjxF29UkWw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.13.tgz",
+      "integrity": "sha512-VndeGvKmTXFn6AGwjy0Kg8i7HccOCE7Jt/vmZwRxGtOfNZM1RLYRQ7MfDLo6T0h1Bq6eYzps3L5Ma4zBmjOnOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.13.tgz",
+      "integrity": "sha512-SmZ9m+XqCB35NddHCctvHFLqPZDAs5j8IgD36GoutufDJmeq2VNfgk5rQoqNqKmAK3Y7iFdEmI76QoHIWiCLyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.13.tgz",
+      "integrity": "sha512-5rij+vB9a29aNkHq72EXI2ihDZPszJb4zlApJY4aCC/q6utgqFA6CkrfTfIb+O8hxtG3zP5KERETz8mfFK6A0A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.13.tgz",
+      "integrity": "sha512-OlSlaOK9JplQ5qn07WiBLibkOw7iml2++ojEXhhR3rbWrNEKCD7sd8+6wSavsInyFdw4PhLA+Hy6YyDBIE23Yw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.13.tgz",
+      "integrity": "sha512-zwQii5YVdsfG8Ti9gIKgBKZg8qMkRZxl+OlYWUT5D93Jl4NuNBRausP20tfEkQdAPSRrMCSUZBM6FhW7izAZRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.13.tgz",
+      "integrity": "sha512-hYXvyVVntqRlYoAIDwNzkS3tL2ijP3rxyWQMNKaxcCxxkCDto/w3meOK/OB6rbQSkNw0qTUcBfU9k+T0ptYdfQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.13.tgz",
+      "integrity": "sha512-XTzKs7c/vYCcjmcwawnQvlHHNS1naJEAzcBckMI5OJlnrcgW8UtcX9NHFYvNjGtXuKv0/9KvqL4fuahdvlNGKw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -6148,6 +6674,15 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.25",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
+      "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -10613,7 +11148,6 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -10868,9 +11402,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -14141,6 +14673,21 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/icu-minify": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.8.3.tgz",
+      "integrity": "sha512-65Av7FLosNk7bPbmQx5z5XG2Y3T2GFppcjiXh4z1idHeVgQxlDpAmkGoYI0eFzAvrOnjpWTL5FmPDhsdfRMPEA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -14303,6 +14850,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.1.2.tgz",
+      "integrity": "sha512-ucSrQmZGAxfiBHfBRXW/k7UC8MaGFlEj4Ry1tKiDcmgwQm1y3EDl40u+4VNHYomxJQMJi9NEI3riDRlth96jKg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "3.1.1",
+        "@formatjs/fast-memoize": "3.1.0",
+        "@formatjs/icu-messageformat-parser": "3.5.1",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/ip-address": {
@@ -14524,7 +15083,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14593,7 +15151,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -17070,6 +17627,91 @@
         }
       }
     },
+    "node_modules/next-intl": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.8.3.tgz",
+      "integrity": "sha512-PvdBDWg+Leh7BR7GJUQbCDVVaBRn37GwDBWc9sv0rVQOJDQ5JU1rVzx9EEGuOGYo0DHAl70++9LQ7HxTawdL7w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.8.1",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "icu-minify": "^4.8.3",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.8.3",
+        "po-parser": "^2.1.1",
+        "use-intl": "^4.8.3"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl-swc-plugin-extractor": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.8.3.tgz",
+      "integrity": "sha512-YcaT+R9z69XkGhpDarVFWUprrCMbxgIQYPUaXoE6LGVnLjGdo8hu3gL6bramDVjNKViYY8a/pXPy7Bna0mXORg==",
+      "license": "MIT"
+    },
+    "node_modules/next-intl/node_modules/@swc/core": {
+      "version": "1.15.13",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.13.tgz",
+      "integrity": "sha512-0l1gl/72PErwUZuavcRpRAQN9uSst+Nk++niC5IX6lmMWpXoScYx3oq/narT64/sKv/eRiPTaAjBFGDEQiWJIw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.25"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.13",
+        "@swc/core-darwin-x64": "1.15.13",
+        "@swc/core-linux-arm-gnueabihf": "1.15.13",
+        "@swc/core-linux-arm64-gnu": "1.15.13",
+        "@swc/core-linux-arm64-musl": "1.15.13",
+        "@swc/core-linux-x64-gnu": "1.15.13",
+        "@swc/core-linux-x64-musl": "1.15.13",
+        "@swc/core-win32-arm64-msvc": "1.15.13",
+        "@swc/core-win32-ia32-msvc": "1.15.13",
+        "@swc/core-win32-x64-msvc": "1.15.13"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next-pwa": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/next-pwa/-/next-pwa-5.6.0.tgz",
@@ -17245,6 +17887,12 @@
       "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
       "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
     "node_modules/node-exports-info": {
@@ -18133,6 +18781,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/po-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+      "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==",
+      "license": "MIT"
     },
     "node_modules/polished": {
       "version": "4.3.1",
@@ -21816,7 +22470,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -22088,6 +22742,27 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-intl": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.8.3.tgz",
+      "integrity": "sha512-nLxlC/RH+le6g3amA508Itnn/00mE+J22ui21QhOWo5V9hCEC43+WtnRAITbJW0ztVZphev5X9gvOf2/Dk9PLA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.8.3",
+        "intl-messageformat": "^11.1.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",


### PR DESCRIPTION
## Add Multi-language Support (i18n)

Closes #245

### Changes
- Added next-intl for internationalization
- 5 languages: English, Spanish, French, Portuguese, Swahili
- Language selector in header
- Locale-aware date/currency formatting
- Language preference persists in localStorage

### Files
- Translation files: `frontend/src/locales/*.json`
- Components: `LanguageSelector.tsx`, `useTranslation.ts`
- Config: `i18n.ts`, `middleware.ts`
- Restructured app with `[locale]` routing

### Testing
- Switch languages via header dropdown
- Verify translations display correctly
- Check localStorage persistence

All acceptance criteria met ✅