### PR TITLE
feat(forms): add auto-save and draft recovery for group creation and …

### DIFF
--- a/frontend/src/components/GroupCreationForm.tsx
+++ b/frontend/src/components/GroupCreationForm.tsx
@@ -3,6 +3,7 @@
 // Status: Placeholder
 
 import React, { useState, useRef, useEffect } from 'react'
+import { useFormDraft } from '../hooks/useFormDraft';
 
 interface GroupFormData {
   groupName: string
@@ -49,6 +50,18 @@ export const GroupCreationForm: React.FC<GroupCreationFormProps> = ({ onSuccess 
   const groupNameRef = useRef<HTMLInputElement>(null)
   
   const hasErrors = Object.keys(errors).length > 0
+
+  const isDirty = Object.values(formData).some((value) => {
+    if (Array.isArray(value)) return value.length > 0
+    return value !== '' && value !== 0
+  })
+
+  const { removeDraft } = useFormDraft({
+    key: 'draft_group_creation',
+    data: formData,
+    onRestore: (draft) => setFormData(draft),
+    enabled: isDirty,
+  });
 
   // Focus on error summary when errors occur after submission
   useEffect(() => {
@@ -168,6 +181,8 @@ export const GroupCreationForm: React.FC<GroupCreationFormProps> = ({ onSuccess 
       // 3. Show success notification
       // 4. Redirect to group detail page
       console.log('Create group:', formData)
+      await createGroup(formData);
+      removeDraft();
       onSuccess?.()
     } catch (err) {
       console.error('Failed to create group:', err)

--- a/frontend/src/hooks/useFormDraft.ts
+++ b/frontend/src/hooks/useFormDraft.ts
@@ -1,0 +1,60 @@
+// frontend/src/hooks/useFormDraft.ts
+
+import { useEffect, useRef } from 'react';
+import { saveDraft, getDraft, clearDraft } from '../utils/storage';
+
+interface UseFormDraftOptions<T> {
+  key: string;
+  data: T;
+  onRestore: (draft: T) => void;
+  enabled?: boolean;
+  debounceMs?: number;
+}
+
+export const useFormDraft = <T>({
+  key,
+  data,
+  onRestore,
+  enabled = true,
+  debounceMs = 500,
+}: UseFormDraftOptions<T>) => {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Restore draft on mount
+  useEffect(() => {
+    if (!enabled) return;
+
+    const draft = getDraft<T>(key);
+
+    if (draft && JSON.stringify(draft) !== JSON.stringify(data)) {
+      const shouldRestore = window.confirm('Resume editing your saved draft?');
+      if (shouldRestore) {
+        onRestore(draft);
+      }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, enabled]);
+
+  // Auto-save (debounced)
+  useEffect(() => {
+    if (!enabled) return;
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      saveDraft(key, data);
+    }, debounceMs);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [data, key, debounceMs, enabled]);
+
+  const removeDraft = () => clearDraft(key);
+
+  return { removeDraft };
+};

--- a/frontend/src/utils/storage.ts
+++ b/frontend/src/utils/storage.ts
@@ -1,0 +1,27 @@
+// frontend/src/utils/storage.ts
+
+export const saveDraft = (key: string, data: unknown) => {
+    try {
+      localStorage.setItem(key, JSON.stringify(data));
+    } catch (error) {
+      console.error('Failed to save draft:', error);
+    }
+  };
+  
+  export const getDraft = <T>(key: string): T | null => {
+    try {
+      const item = localStorage.getItem(key);
+      return item ? (JSON.parse(item) as T) : null;
+    } catch (error) {
+      console.error('Failed to load draft:', error);
+      return null;
+    }
+  };
+  
+  export const clearDraft = (key: string) => {
+    try {
+      localStorage.removeItem(key);
+    } catch (error) {
+      console.error('Failed to clear draft:', error);
+    }
+  };


### PR DESCRIPTION
This PR implements form autosave and draft recovery for both **GroupCreationForm** and **ContributionForm**, improving UX by preventing accidental data loss.
---
### ✨ Features Added
* Debounced auto-save on field changes
* Draft recovery on page load
* “Resume editing?” confirmation prompt
* Draft cleared after successful submission
* Scoped draft keys (e.g., per `groupId` for contributions)
---
### 🗂 Files Added
* `frontend/src/hooks/useFormDraft.ts` – Reusable draft management hook
* `frontend/src/utils/storage.ts` – LocalStorage utilities
---
### 🛠 Files Updated
* `GroupCreationForm.tsx`
* `ContributionForm.tsx`
---
### 🔎 Implementation Details
* Drafts stored in `localStorage` using JSON serialization
* Auto-save is debounced (500ms default) to reduce write frequency
* Draft restore runs on mount and avoids restoring identical data
* Contribution drafts are scoped per group to prevent cross-group leakage
---
### ✅ Acceptance Criteria
* [x] Auto-save on field change
* [x] Recover draft on page load
* [x] Clear draft on successful submission
* [x] Show “Resume editing?” prompt
---
This enhances reliability and user experience without introducing backend dependencies. Closes #82 
