### PR TITLE
feat(contracts): add group milestone and member achievement system

### DIFF
--- a/contracts/ajo/src/contract.rs
+++ b/contracts/ajo/src/contract.rs
@@ -4,7 +4,10 @@ use crate::errors::AjoError;
 use crate::events;
 use crate::pausable;
 use crate::storage;
-use crate::types::{Group, GroupMetadata, GroupStatus, PayoutOrderingStrategy};
+use crate::types::{
+    AchievementRecord, Group, GroupMetadata, GroupStatus, MemberStats,
+    MilestoneRecord, PayoutOrderingStrategy,
+};
 use crate::utils;
 
 /// The main Ajo contract
@@ -349,6 +352,12 @@ impl AjoContract {
         // Emit event
         events::emit_member_joined(&env, group_id, &member);
 
+        // Update member stats
+        let mut stats = storage::get_member_stats(&env, &member)
+            .unwrap_or_else(|| utils::default_member_stats(&env, &member));
+        stats.total_groups_joined += 1;
+        storage::store_member_stats(&env, &member, &stats);
+
         Ok(())
     }
 
@@ -466,6 +475,27 @@ impl AjoContract {
             current_cycle,
             contribution_amount,
         );
+
+        // Update member stats
+        let mut stats = storage::get_member_stats(&env, &member)
+            .unwrap_or_else(|| utils::default_member_stats(&env, &member));
+        stats.total_contributions += 1;
+        stats.on_time_contributions += 1;
+        stats.total_amount_contributed += contribution_amount;
+        storage::store_member_stats(&env, &member, &stats);
+
+        // Check and record member achievements
+        let achievements = utils::check_member_achievements(&env, &member, &stats);
+        for achievement in achievements.iter() {
+            let record = AchievementRecord {
+                member: member.clone(),
+                achievement,
+                earned_at: utils::get_current_timestamp(&env),
+                group_id: group_id_cached,
+            };
+            storage::add_member_achievement(&env, &member, &record);
+            events::emit_achievement_earned(&env, &member, record.achievement as u32, group_id_cached);
+        }
 
         Ok(())
     }
@@ -646,6 +676,29 @@ impl AjoContract {
 
         // Update storage (single write)
         storage::store_group(&env, group_id, &group);
+
+        // Check and record group milestones
+        let milestones = utils::check_group_milestones(&env, &group);
+        for milestone in milestones.iter() {
+            let record = MilestoneRecord {
+                group_id: group.id,
+                milestone,
+                achieved_at: utils::get_current_timestamp(&env),
+                cycle_number: current_cycle,
+            };
+            storage::add_group_milestone(&env, group.id, &record);
+            events::emit_milestone_achieved(&env, group.id, record.milestone as u32, current_cycle);
+        }
+
+        // If group completed, update member stats for all members
+        if group.is_complete {
+            for member in group.members.iter() {
+                let mut stats = storage::get_member_stats(&env, &member)
+                    .unwrap_or_else(|| utils::default_member_stats(&env, &member));
+                stats.total_groups_completed += 1;
+                storage::store_member_stats(&env, &member, &stats);
+            }
+        }
 
         Ok(())
     }
@@ -1567,5 +1620,36 @@ impl AjoContract {
         cycle: u32,
     ) -> Result<crate::types::PayoutOrder, AjoError> {
         storage::get_payout_order(&env, group_id, cycle).ok_or(AjoError::GroupNotFound)
+    }
+
+    // ── Milestones & Achievements ─────────────────────────────────────────
+
+    /// Returns all milestones achieved by a group.
+    pub fn get_group_milestones(
+        env: Env,
+        group_id: u64,
+    ) -> Result<Vec<MilestoneRecord>, AjoError> {
+        // Verify group exists
+        storage::get_group(&env, group_id).ok_or(AjoError::GroupNotFound)?;
+        Ok(storage::get_group_milestones(&env, group_id)
+            .unwrap_or_else(|| Vec::new(&env)))
+    }
+
+    /// Returns all achievements earned by a member.
+    pub fn get_member_achievements(
+        env: Env,
+        member: Address,
+    ) -> Result<Vec<AchievementRecord>, AjoError> {
+        Ok(storage::get_member_achievements(&env, &member)
+            .unwrap_or_else(|| Vec::new(&env)))
+    }
+
+    /// Returns aggregated statistics for a member across all groups.
+    pub fn get_member_stats(
+        env: Env,
+        member: Address,
+    ) -> Result<MemberStats, AjoError> {
+        Ok(storage::get_member_stats(&env, &member)
+            .unwrap_or_else(|| utils::default_member_stats(&env, &member)))
     }
 }

--- a/contracts/ajo/src/events.rs
+++ b/contracts/ajo/src/events.rs
@@ -157,3 +157,25 @@ pub fn emit_payout_order_determined(
     let topics = (symbol_short!("porder"), group_id, cycle);
     env.events().publish(topics, (recipient, strategy));
 }
+
+/// Emit an event when a group milestone is achieved
+pub fn emit_milestone_achieved(
+    env: &Env,
+    group_id: u64,
+    milestone: u32,
+    cycle: u32,
+) {
+    let topics = (symbol_short!("mileston"), group_id);
+    env.events().publish(topics, (milestone, cycle));
+}
+
+/// Emit an event when a member earns an achievement
+pub fn emit_achievement_earned(
+    env: &Env,
+    member: &Address,
+    achievement: u32,
+    group_id: u64,
+) {
+    let topics = (symbol_short!("achieve"), group_id);
+    env.events().publish(topics, (member, achievement));
+}

--- a/contracts/ajo/src/lib.rs
+++ b/contracts/ajo/src/lib.rs
@@ -28,3 +28,4 @@ pub use contract::AjoContractClient;
 pub use errors::AjoError;
 pub use types::{GroupState, RefundReason, RefundRequest, RefundRecord, RefundVote};
 pub use types::{PayoutOrderingStrategy, PayoutVote, PayoutOrder};
+pub use types::{GroupMilestone, MemberAchievement, MilestoneRecord, AchievementRecord, MemberStats};

--- a/contracts/ajo/src/storage.rs
+++ b/contracts/ajo/src/storage.rs
@@ -58,6 +58,18 @@ pub enum StorageKey {
     /// Global insurance claim counter.
     /// Stored in instance storage under `"ICONT"`.
     ClaimCounter,
+
+    /// Group milestones list.
+    /// Stored in persistent storage under `("GMILE", group_id)`.
+    GroupMilestones(u64),
+
+    /// Member achievements list.
+    /// Stored in persistent storage under `("MACHIEV", member)`.
+    MemberAchievements(Address),
+
+    /// Aggregated member statistics.
+    /// Stored in persistent storage under `("MSTATS", member)`.
+    MemberStatsData(Address),
 }
 
 impl StorageKey {
@@ -86,6 +98,9 @@ impl StorageKey {
             StorageKey::InsurancePool(_) => symbol_short!("INSPOOL"),
             StorageKey::InsuranceClaim(_) => symbol_short!("INSCLAIM"),
             StorageKey::ClaimCounter => symbol_short!("ICONT"),
+            StorageKey::GroupMilestones(_) => symbol_short!("GMILE"),
+            StorageKey::MemberAchievements(_) => symbol_short!("MACHIEV"),
+            StorageKey::MemberStatsData(_) => symbol_short!("MSTATS"),
         }
     }
 }
@@ -629,5 +644,59 @@ pub fn get_payout_order(
     cycle: u32,
 ) -> Option<crate::types::PayoutOrder> {
     let key = (symbol_short!("PORDER"), group_id, cycle);
+    env.storage().persistent().get(&key)
+}
+
+// ── Milestone & achievement storage ───────────────────────────────────────
+
+/// Stores group milestones list.
+pub fn store_group_milestones(env: &Env, group_id: u64, milestones: &Vec<crate::types::MilestoneRecord>) {
+    let key = (symbol_short!("GMILE"), group_id);
+    env.storage().persistent().set(&key, milestones);
+}
+
+/// Retrieves group milestones.
+pub fn get_group_milestones(env: &Env, group_id: u64) -> Option<Vec<crate::types::MilestoneRecord>> {
+    let key = (symbol_short!("GMILE"), group_id);
+    env.storage().persistent().get(&key)
+}
+
+/// Adds a single milestone to a group's milestone list.
+pub fn add_group_milestone(env: &Env, group_id: u64, record: &crate::types::MilestoneRecord) {
+    let mut milestones = get_group_milestones(env, group_id)
+        .unwrap_or_else(|| Vec::new(env));
+    milestones.push_back(record.clone());
+    store_group_milestones(env, group_id, &milestones);
+}
+
+/// Stores member achievements list.
+pub fn store_member_achievements(env: &Env, member: &Address, achievements: &Vec<crate::types::AchievementRecord>) {
+    let key = (symbol_short!("MACHIEV"), member);
+    env.storage().persistent().set(&key, achievements);
+}
+
+/// Retrieves member achievements.
+pub fn get_member_achievements(env: &Env, member: &Address) -> Option<Vec<crate::types::AchievementRecord>> {
+    let key = (symbol_short!("MACHIEV"), member);
+    env.storage().persistent().get(&key)
+}
+
+/// Adds a single achievement to a member's list.
+pub fn add_member_achievement(env: &Env, member: &Address, record: &crate::types::AchievementRecord) {
+    let mut achievements = get_member_achievements(env, member)
+        .unwrap_or_else(|| Vec::new(env));
+    achievements.push_back(record.clone());
+    store_member_achievements(env, member, &achievements);
+}
+
+/// Stores aggregated member statistics.
+pub fn store_member_stats(env: &Env, member: &Address, stats: &crate::types::MemberStats) {
+    let key = (symbol_short!("MSTATS"), member);
+    env.storage().persistent().set(&key, stats);
+}
+
+/// Retrieves aggregated member statistics.
+pub fn get_member_stats(env: &Env, member: &Address) -> Option<crate::types::MemberStats> {
+    let key = (symbol_short!("MSTATS"), member);
     env.storage().persistent().get(&key)
 }

--- a/contracts/ajo/src/types.rs
+++ b/contracts/ajo/src/types.rs
@@ -392,3 +392,63 @@ pub struct InsurancePool {
     /// Total amount of claims filed.
     pub pending_claims_count: u32,
 }
+
+/// Group-level milestones that track progress through the savings cycle.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum GroupMilestone {
+    FirstPayout = 0,
+    HalfwayComplete = 1,
+    ThreeQuartersComplete = 2,
+    FullyCompleted = 3,
+    PerfectAttendance = 4,
+    ZeroPenalties = 5,
+}
+
+/// Individual member achievements earned through participation.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum MemberAchievement {
+    FirstContribution = 0,
+    PerfectAttendance = 1,
+    EarlyBird = 2,
+    Reliable = 3,
+    Veteran = 4,
+    HighRoller = 5,
+}
+
+/// Records a group milestone with context.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MilestoneRecord {
+    pub group_id: u64,
+    pub milestone: GroupMilestone,
+    pub achieved_at: u64,
+    pub cycle_number: u32,
+}
+
+/// Records a member achievement with context.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AchievementRecord {
+    pub member: Address,
+    pub achievement: MemberAchievement,
+    pub earned_at: u64,
+    pub group_id: u64,
+}
+
+/// Aggregated statistics for a member across all groups.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MemberStats {
+    pub member: Address,
+    pub total_groups_joined: u32,
+    pub total_groups_completed: u32,
+    pub total_contributions: u32,
+    pub on_time_contributions: u32,
+    pub late_contributions: u32,
+    pub total_amount_contributed: i128,
+    pub achievements: Vec<MemberAchievement>,
+}

--- a/contracts/ajo/src/utils.rs
+++ b/contracts/ajo/src/utils.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{Address, Env, Vec};
 
-use crate::types::{Group, PayoutOrder, PayoutOrderingStrategy};
+use crate::types::{Group, GroupMilestone, MemberAchievement, PayoutOrder, PayoutOrderingStrategy};
 use crate::errors::AjoError;
 
 /// Returns `true` if `address` appears in the group's `members` list.
@@ -311,4 +311,123 @@ fn get_eligible_members(env: &Env, group: &Group) -> Result<Vec<Address>, AjoErr
         return Err(AjoError::NoEligibleMembers);
     }
     Ok(eligible)
+}
+
+// ── Milestone & achievement detection ─────────────────────────────────────
+
+/// Checks which group milestones have been newly achieved based on group state.
+pub fn check_group_milestones(env: &Env, group: &Group) -> Vec<GroupMilestone> {
+    let mut milestones = Vec::new(env);
+
+    let total_cycles = group.members.len() as u32;
+    let completed_cycles = group.payout_index;
+
+    // First payout
+    if completed_cycles == 1 {
+        milestones.push_back(GroupMilestone::FirstPayout);
+    }
+
+    // Halfway complete
+    if total_cycles >= 2 && completed_cycles == total_cycles / 2 {
+        milestones.push_back(GroupMilestone::HalfwayComplete);
+    }
+
+    // Three quarters complete
+    if total_cycles >= 4 && completed_cycles == (total_cycles * 3) / 4 {
+        milestones.push_back(GroupMilestone::ThreeQuartersComplete);
+    }
+
+    // Fully completed
+    if group.is_complete {
+        milestones.push_back(GroupMilestone::FullyCompleted);
+
+        // Check for perfect attendance (all members on-time every cycle)
+        if check_perfect_attendance(env, group) {
+            milestones.push_back(GroupMilestone::PerfectAttendance);
+        }
+
+        // Check for zero penalties
+        if check_zero_penalties(env, group) {
+            milestones.push_back(GroupMilestone::ZeroPenalties);
+        }
+    }
+
+    milestones
+}
+
+/// Returns true if all members contributed on time every cycle (no late contributions).
+fn check_perfect_attendance(env: &Env, group: &Group) -> bool {
+    for member in group.members.iter() {
+        if let Some(penalty) = crate::storage::get_member_penalty(env, group.id, &member) {
+            if penalty.late_count > 0 {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Returns true if no penalties were incurred across all cycles.
+fn check_zero_penalties(env: &Env, group: &Group) -> bool {
+    let total_cycles = group.members.len() as u32;
+    for cycle in 1..=total_cycles {
+        let pool = crate::storage::get_cycle_penalty_pool(env, group.id, cycle);
+        if pool > 0 {
+            return false;
+        }
+    }
+    true
+}
+
+/// Checks which member achievements have been newly earned.
+pub fn check_member_achievements(
+    env: &Env,
+    member: &Address,
+    stats: &crate::types::MemberStats,
+) -> Vec<MemberAchievement> {
+    let mut achievements = Vec::new(env);
+
+    // First contribution
+    if stats.total_contributions == 1 {
+        achievements.push_back(MemberAchievement::FirstContribution);
+    }
+
+    // Reliable (95%+ on-time rate)
+    if stats.total_contributions >= 5 {
+        let on_time_rate = (stats.on_time_contributions * 100) / stats.total_contributions;
+        if on_time_rate >= 95 {
+            achievements.push_back(MemberAchievement::Reliable);
+        }
+    }
+
+    // Veteran (5+ completed groups)
+    if stats.total_groups_completed >= 5 {
+        achievements.push_back(MemberAchievement::Veteran);
+    }
+
+    // High roller (1M+ XLM = 10^13 stroops contributed)
+    if stats.total_amount_contributed >= 10_000_000_000_000 {
+        achievements.push_back(MemberAchievement::HighRoller);
+    }
+
+    // Perfect attendance check (no late contributions ever)
+    if stats.total_contributions >= 10 && stats.late_contributions == 0 {
+        achievements.push_back(MemberAchievement::PerfectAttendance);
+    }
+
+    achievements
+}
+
+/// Initializes default MemberStats for a new member.
+pub fn default_member_stats(env: &Env, member: &Address) -> crate::types::MemberStats {
+    crate::types::MemberStats {
+        member: member.clone(),
+        total_groups_joined: 0,
+        total_groups_completed: 0,
+        total_contributions: 0,
+        on_time_contributions: 0,
+        late_contributions: 0,
+        total_amount_contributed: 0,
+        achievements: Vec::new(env),
+    }
 }


### PR DESCRIPTION
## Summary

- Added `GroupMilestone` enum tracking group-level progress: FirstPayout, HalfwayComplete, ThreeQuartersComplete, FullyCompleted, PerfectAttendance, and ZeroPenalties
- Added `MemberAchievement` enum for individual achievements: FirstContribution, PerfectAttendance, EarlyBird, Reliable, Veteran, and HighRoller
- Added `MemberStats` struct that aggregates member statistics across all groups (total groups joined/completed, contribution counts, on-time/late splits, total amount contributed)
- Milestone detection runs automatically after each `execute_payout`, recording milestones with timestamps and cycle context
- Achievement detection runs after each `contribute`, checking cumulative stats against achievement thresholds
- Member stats update automatically on `join_group` (groups joined count), `contribute` (contribution counts and amounts), and `execute_payout` (groups completed)
- All milestones and achievements emit events for indexing and gamification
- Three new read-only contract endpoints: `get_group_milestones`, `get_member_achievements`, `get_member_stats`

## Files changed
- `contracts/ajo/src/types.rs` - New milestone, achievement, and stats types
- `contracts/ajo/src/storage.rs` - Storage keys and CRUD helpers for milestones, achievements, and stats
- `contracts/ajo/src/events.rs` - Event emission for milestone and achievement triggers
- `contracts/ajo/src/utils.rs` - Detection logic for milestones and achievements
- `contracts/ajo/src/contract.rs` - Integration into contribute/payout flows and new query endpoints
- `contracts/ajo/src/lib.rs` - Public exports for new types

## Test plan

- [ ] Verify MemberStats increments on join_group and contribute
- [ ] Verify FirstContribution achievement earned on first contribution
- [ ] Verify FirstPayout milestone recorded after first payout
- [ ] Verify HalfwayComplete milestone at correct cycle
- [ ] Verify FullyCompleted + PerfectAttendance + ZeroPenalties when group completes with no late contributions
- [ ] Verify Reliable achievement triggers at 95%+ on-time rate with 5+ contributions
- [ ] Verify Veteran achievement after 5 completed groups
- [ ] Verify get_group_milestones returns empty vec for new group
- [ ] Verify get_member_stats returns default values for new member
- [ ] Verify events are emitted for each milestone and achievement

Closes #342