### PR TITLE
Added Request Validation with Zod Schemas

### DIFF
--- a/backend/src/controllers/goalsController.ts
+++ b/backend/src/controllers/goalsController.ts
@@ -2,156 +2,90 @@ import { Request, Response } from 'express'
 import { PrismaClient } from '@prisma/client'
 import { asyncHandler } from '../middleware/errorHandler'
 import { AppError } from '../errors/AppError'
-import { z } from 'zod'
 
 const prisma = new PrismaClient()
 
-// Schemas for validation
-const createGoalSchema = z.object({
-  title: z.string().min(1),
-  description: z.string().optional(),
-  targetAmount: z
-    .string()
-    .or(z.number())
-    .transform((val) => BigInt(val)),
-  deadline: z.string().transform((str) => new Date(str)),
-  category: z.enum(['EMERGENCY', 'VACATION', 'EDUCATION', 'HOME', 'RETIREMENT', 'CUSTOM']),
-  isPublic: z.boolean().optional(),
-})
-
-const updateGoalSchema = z.object({
-  title: z.string().optional(),
-  description: z.string().optional(),
-  targetAmount: z
-    .string()
-    .or(z.number())
-    .optional()
-    .transform((val) => (val ? BigInt(val) : undefined)),
-  deadline: z
-    .string()
-    .optional()
-    .transform((str) => (str ? new Date(str) : undefined)),
-  category: z
-    .enum(['EMERGENCY', 'VACATION', 'EDUCATION', 'HOME', 'RETIREMENT', 'CUSTOM'])
-    .optional(),
-  isPublic: z.boolean().optional(),
-  status: z.enum(['ACTIVE', 'COMPLETED', 'ARCHIVED']).optional(),
-})
-
-const affordabilitySchema = z.object({
-  monthlyIncome: z.number(),
-  monthlyExpenses: z.number(),
-  goalTarget: z.number(),
-  goalDeadline: z.string().transform((str) => new Date(str)),
-})
-
-// Helper to handle BigInt in JSON
-const serializeBigInt = (data: any) => {
-  return JSON.parse(JSON.stringify(data, (_, v) => (typeof v === 'bigint' ? v.toString() : v)))
-}
+const serializeBigInt = (data: unknown) =>
+  JSON.parse(JSON.stringify(data, (_, v) => (typeof v === 'bigint' ? v.toString() : v)))
 
 export class GoalsController {
-  // Create a new goal
   createGoal = asyncHandler(async (req: Request, res: Response) => {
-    // Assuming auth middleware populates req.user
     const userId = (req as any).user?.publicKey || req.body.userId
+    if (!userId) throw new AppError('User ID is required', 'UNAUTHORIZED', 401)
 
-    if (!userId) {
-      throw new AppError('User ID is required', 'UNAUTHORIZED', 401)
-    }
-
-    const validatedData = createGoalSchema.parse(req.body)
+    const { title, description, targetAmount, deadline, category, isPublic } = req.body
 
     const goal = await prisma.goal.create({
       data: {
-        ...validatedData,
+        title,
+        description,
+        targetAmount: BigInt(targetAmount),
+        deadline: new Date(deadline),
+        category,
+        isPublic: isPublic ?? false,
         userId,
         currentAmount: BigInt(0),
       },
     })
 
-    res.status(201).json({
-      success: true,
-      data: serializeBigInt(goal),
-    })
+    res.status(201).json({ success: true, data: serializeBigInt(goal) })
   })
 
-  // Get all goals for the user
   getGoals = asyncHandler(async (req: Request, res: Response) => {
     const userId = (req as any).user?.publicKey || req.query.userId
-
-    if (!userId) {
-      throw new AppError('User ID is required', 'UNAUTHORIZED', 401)
-    }
+    if (!userId) throw new AppError('User ID is required', 'UNAUTHORIZED', 401)
 
     const goals = await prisma.goal.findMany({
       where: { userId: String(userId) },
       orderBy: { createdAt: 'desc' },
     })
 
-    res.status(200).json({
-      success: true,
-      data: serializeBigInt(goals),
-    })
+    res.status(200).json({ success: true, data: serializeBigInt(goals) })
   })
 
-  // Get a single goal
   getGoal = asyncHandler(async (req: Request, res: Response) => {
     const { id } = req.params
-    const goal = await prisma.goal.findUnique({
-      where: { id },
-      include: { members: true },
-    })
+    const goal = await prisma.goal.findUnique({ where: { id }, include: { members: true } })
 
-    if (!goal) {
-      throw new AppError('Goal not found', 'NOT_FOUND', 404)
-    }
+    if (!goal) throw new AppError('Goal not found', 'NOT_FOUND', 404)
 
-    res.status(200).json({
-      success: true,
-      data: serializeBigInt(goal),
-    })
+    res.status(200).json({ success: true, data: serializeBigInt(goal) })
   })
 
-  // Update a goal
   updateGoal = asyncHandler(async (req: Request, res: Response) => {
     const { id } = req.params
-    const validatedData = updateGoalSchema.parse(req.body)
+    const { title, description, targetAmount, deadline, category, isPublic, status } = req.body
 
     const goal = await prisma.goal.update({
       where: { id },
-      data: validatedData,
+      data: {
+        ...(title !== undefined && { title }),
+        ...(description !== undefined && { description }),
+        ...(targetAmount !== undefined && { targetAmount: BigInt(targetAmount) }),
+        ...(deadline !== undefined && { deadline: new Date(deadline) }),
+        ...(category !== undefined && { category }),
+        ...(isPublic !== undefined && { isPublic }),
+        ...(status !== undefined && { status }),
+      },
     })
 
-    res.status(200).json({
-      success: true,
-      data: serializeBigInt(goal),
-    })
+    res.status(200).json({ success: true, data: serializeBigInt(goal) })
   })
 
-  // Delete a goal
   deleteGoal = asyncHandler(async (req: Request, res: Response) => {
     const { id } = req.params
-    await prisma.goal.delete({
-      where: { id },
-    })
-
-    res.status(200).json({
-      success: true,
-      message: 'Goal deleted successfully',
-    })
+    await prisma.goal.delete({ where: { id } })
+    res.status(200).json({ success: true, message: 'Goal deleted successfully' })
   })
 
-  // Calculate Affordability
   checkAffordability = asyncHandler(async (req: Request, res: Response) => {
-    const { monthlyIncome, monthlyExpenses, goalTarget, goalDeadline } = affordabilitySchema.parse(
-      req.body
-    )
+    const { monthlyIncome, monthlyExpenses, goalTarget, goalDeadline } = req.body
 
+    const deadline = new Date(goalDeadline)
     const today = new Date()
     const monthsUntilDeadline =
-      (goalDeadline.getFullYear() - today.getFullYear()) * 12 +
-      (goalDeadline.getMonth() - today.getMonth())
+      (deadline.getFullYear() - today.getFullYear()) * 12 +
+      (deadline.getMonth() - today.getMonth())
 
     if (monthsUntilDeadline <= 0) {
       throw new AppError('Deadline must be in the future', 'VALIDATION_ERROR', 400)
@@ -161,7 +95,6 @@ export class GoalsController {
     const disposableIncome = monthlyIncome - monthlyExpenses
 
     let status: 'Sustainable' | 'Aggressive' | 'Unattainable'
-
     if (requiredMonthlySavings <= disposableIncome * 0.3) {
       status = 'Sustainable'
     } else if (requiredMonthlySavings <= disposableIncome * 0.6) {
@@ -172,38 +105,30 @@ export class GoalsController {
 
     res.status(200).json({
       success: true,
-      data: {
-        status,
-        requiredMonthlySavings,
-        disposableIncome,
-        monthsUntilDeadline,
-      },
+      data: { status, requiredMonthlySavings, disposableIncome, monthsUntilDeadline },
     })
   })
 
-  // Future Payout Projection (Compound Interest)
+  // Compound interest projection: A = P(1+r/n)^(nt) + PMT*(((1+r/n)^(nt)-1)/(r/n))
   calculateProjection = asyncHandler(async (req: Request, res: Response) => {
     const { principal, monthlyContribution, interestRate, years } = req.body
 
-    // A = P(1 + r/n)^(nt) + PMT * (((1 + r/n)^(nt) - 1) / (r/n))
-    // Assuming monthly compounding (n=12)
-
-    const P = Number(principal) || 0
-    const PMT = Number(monthlyContribution) || 0
-    const r = (Number(interestRate) || 0) / 100
-    const t = Number(years) || 1
+    const P = Number(principal)
+    const PMT = Number(monthlyContribution)
+    const r = Number(interestRate) / 100
+    const t = Number(years)
     const n = 12
 
     const compoundInterest = P * Math.pow(1 + r / n, n * t)
-    const futureValueContributions = PMT * ((Math.pow(1 + r / n, n * t) - 1) / (r / n))
-
-    const totalAmount = compoundInterest + (r > 0 ? futureValueContributions : PMT * n * t)
+    const futureValueContributions =
+      r > 0 ? PMT * ((Math.pow(1 + r / n, n * t) - 1) / (r / n)) : PMT * n * t
+    const totalAmount = compoundInterest + futureValueContributions
 
     res.status(200).json({
       success: true,
       data: {
         totalAmount,
-        principal,
+        principal: P,
         totalContributions: PMT * n * t,
         interestEarned: totalAmount - P - PMT * n * t,
       },

--- a/backend/src/middleware/validateRequest.ts
+++ b/backend/src/middleware/validateRequest.ts
@@ -1,51 +1,52 @@
 import { Request, Response, NextFunction } from 'express'
-import { AnyZodObject, ZodError } from 'zod'
+import { AnyZodObject, ZodError, ZodSchema } from 'zod'
+import { formatZodErrors } from '../utils/zodHelpers'
 
-/**
- * Middleware factory for validating requests using Zod schemas
- * Supports validation of body, query, and params
- */
-export const validateRequest = (schema: {
+type SchemaMap = {
   body?: AnyZodObject
   query?: AnyZodObject
   params?: AnyZodObject
-}) => {
+}
+
+/**
+ * Middleware factory for validating requests using Zod schemas.
+ *
+ * Accepts either:
+ *   - A SchemaMap: { body?, query?, params? } — validates each part independently
+ *   - A single ZodSchema + source ('body' | 'query' | 'params') — legacy single-source mode
+ */
+export const validateRequest = (
+  schema: SchemaMap | ZodSchema,
+  source?: 'body' | 'query' | 'params'
+) => {
   return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      // Validate body if schema provided
-      if (schema.body) {
-        req.body = await schema.body.parseAsync(req.body)
+      if (isSchemaMap(schema)) {
+        if (schema.body) req.body = await schema.body.parseAsync(req.body)
+        if (schema.query) req.query = await schema.query.parseAsync(req.query)
+        if (schema.params) req.params = await schema.params.parseAsync(req.params)
+      } else {
+        const target = source ?? 'body'
+        req[target] = await (schema as ZodSchema).parseAsync(req[target])
       }
-
-      // Validate query if schema provided
-      if (schema.query) {
-        req.query = await schema.query.parseAsync(req.query)
-      }
-
-      // Validate params if schema provided
-      if (schema.params) {
-        req.params = await schema.params.parseAsync(req.params)
-      }
-
       next()
     } catch (error) {
       if (error instanceof ZodError) {
-        // Format Zod validation errors
-        const formattedErrors = error.errors.map((err) => ({
-          field: err.path.join('.'),
-          message: err.message,
-        }))
-
         res.status(400).json({
           success: false,
           error: 'Validation failed',
-          details: formattedErrors,
+          details: formatZodErrors(error),
         })
         return
       }
-
-      // Pass other errors to error handler
       next(error)
     }
   }
 }
+
+function isSchemaMap(schema: SchemaMap | ZodSchema): schema is SchemaMap {
+  return typeof schema === 'object' && !('parseAsync' in schema)
+}
+
+/** Alias for backward compatibility */
+export const validate = validateRequest

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,26 +1,19 @@
 import { Router, Request, Response } from 'express'
 import { AuthService } from '../services/authService'
-import { z } from 'zod'
+import { validateRequest } from '../middleware/validateRequest'
+import { generateTokenSchema } from '../schemas/auth.schema'
 
 const router = Router()
 
-const authSchema = z.object({
-  publicKey: z.string().regex(/^G[A-Z0-9]{55}$/, 'Invalid Stellar public key')
-})
-
 // POST /api/auth/token - Generate JWT token
-router.post('/token', (req: Request, res: Response): void => {
-  try {
-    const { publicKey } = authSchema.parse(req.body)
+router.post(
+  '/token',
+  validateRequest({ body: generateTokenSchema }),
+  (req: Request, res: Response): void => {
+    const { publicKey } = req.body
     const token = AuthService.generateToken(publicKey)
     res.json({ token })
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      res.status(400).json({ error: 'Invalid public key format' })
-      return
-    }
-    res.status(500).json({ error: 'Internal server error' })
   }
-})
+)
 
 export const authRouter = router

--- a/backend/src/routes/goals.ts
+++ b/backend/src/routes/goals.ts
@@ -1,18 +1,46 @@
-import { Router } from 'express';
-import { goalsController } from '../controllers/goalsController';
-import { authMiddleware as auth } from '../middleware/auth'; 
+import { Router } from 'express'
+import { goalsController } from '../controllers/goalsController'
+import { authMiddleware as auth } from '../middleware/auth'
+import { validateRequest } from '../middleware/validateRequest'
+import {
+  createGoalSchema,
+  updateGoalSchema,
+  affordabilitySchema,
+  projectionSchema,
+  goalIdParamSchema,
+} from '../schemas/goal.schema'
 
-const router = Router();
+const router = Router()
 
 // Goal Management
-router.post('/', auth, goalsController.createGoal);
-router.get('/', auth, goalsController.getGoals);
-router.get('/:id', auth, goalsController.getGoal);
-router.patch('/:id', auth, goalsController.updateGoal);
-router.delete('/:id', auth, goalsController.deleteGoal);
+router.post('/', auth, validateRequest({ body: createGoalSchema }), goalsController.createGoal)
+router.get('/', auth, goalsController.getGoals)
+router.get('/:id', auth, validateRequest({ params: goalIdParamSchema }), goalsController.getGoal)
+router.patch(
+  '/:id',
+  auth,
+  validateRequest({ params: goalIdParamSchema, body: updateGoalSchema }),
+  goalsController.updateGoal
+)
+router.delete(
+  '/:id',
+  auth,
+  validateRequest({ params: goalIdParamSchema }),
+  goalsController.deleteGoal
+)
 
 // Financial Intelligence Tools
-router.post('/affordability', auth, goalsController.checkAffordability);
-router.post('/projection', auth, goalsController.calculateProjection);
+router.post(
+  '/affordability',
+  auth,
+  validateRequest({ body: affordabilitySchema }),
+  goalsController.checkAffordability
+)
+router.post(
+  '/projection',
+  auth,
+  validateRequest({ body: projectionSchema }),
+  goalsController.calculateProjection
+)
 
-export const goalsRouter = router;
+export const goalsRouter = router

--- a/backend/src/routes/rewards.ts
+++ b/backend/src/routes/rewards.ts
@@ -1,19 +1,17 @@
-import { Router } from 'express';
-import {
-  getRewards,
-  redeemReward,
-  getRewardHistory,
-} from '../controllers/rewardController';
+import { Router } from 'express'
+import { getRewards, redeemReward, getRewardHistory } from '../controllers/rewardController'
+import { validateRequest } from '../middleware/validateRequest'
+import { rewardQuerySchema, rewardIdParamSchema } from '../schemas/reward.schema'
 
-const router = Router();
+const router = Router()
 
 // GET /api/rewards - Get all rewards for authenticated user
-router.get('/', getRewards);
+router.get('/', validateRequest({ query: rewardQuerySchema }), getRewards)
 
 // POST /api/rewards/:id/redeem - Redeem a specific reward
-router.post('/:id/redeem', redeemReward);
+router.post('/:id/redeem', validateRequest({ params: rewardIdParamSchema }), redeemReward)
 
 // GET /api/rewards/history - Get complete reward history
-router.get('/history', getRewardHistory);
+router.get('/history', getRewardHistory)
 
-export default router;
+export default router

--- a/backend/src/schemas/auth.schema.ts
+++ b/backend/src/schemas/auth.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+import { stellarPublicKeySchema } from './common.schema'
+
+export const generateTokenSchema = z.object({
+  publicKey: stellarPublicKeySchema,
+})
+
+export const refreshTokenSchema = z.object({
+  refreshToken: z.string().min(1, 'Refresh token is required'),
+})
+
+export type GenerateTokenInput = z.infer<typeof generateTokenSchema>
+export type RefreshTokenInput = z.infer<typeof refreshTokenSchema>

--- a/backend/src/schemas/common.schema.ts
+++ b/backend/src/schemas/common.schema.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+
+/** Stellar public key: 56 chars, starts with G */
+export const stellarPublicKeySchema = z
+  .string()
+  .regex(/^G[A-Z0-9]{55}$/, 'Invalid Stellar public key format')
+
+/** UUID path param */
+export const uuidParamSchema = z.object({
+  id: z.string().uuid('Invalid ID format'),
+})
+
+/** Generic string ID param (for non-UUID IDs) */
+export const idParamSchema = z.object({
+  id: z.string().min(1, 'ID is required'),
+})
+
+/** Pagination query params */
+export const paginationSchema = z.object({
+  page: z
+    .string()
+    .optional()
+    .transform((val: string | undefined) => (val ? parseInt(val, 10) : 1))
+    .pipe(z.number().int().min(1, 'Page must be at least 1')),
+  limit: z
+    .string()
+    .optional()
+    .transform((val: string | undefined) => (val ? parseInt(val, 10) : 20))
+    .pipe(z.number().int().min(1).max(100, 'Limit must be between 1 and 100')),
+})
+
+/** Offset-based pagination */
+export const offsetPaginationSchema = z.object({
+  limit: z
+    .string()
+    .optional()
+    .transform((val: string | undefined) => (val ? parseInt(val, 10) : 20))
+    .pipe(z.number().int().positive().max(100)),
+  offset: z
+    .string()
+    .optional()
+    .transform((val: string | undefined) => (val ? parseInt(val, 10) : 0))
+    .pipe(z.number().int().min(0)),
+})
+
+export type PaginationQuery = z.infer<typeof paginationSchema>
+export type OffsetPaginationQuery = z.infer<typeof offsetPaginationSchema>
+export type IdParam = z.infer<typeof idParamSchema>

--- a/backend/src/schemas/goal.schema.ts
+++ b/backend/src/schemas/goal.schema.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod'
+import { idParamSchema } from './common.schema'
+
+const goalCategoryEnum = z.enum([
+  'EMERGENCY',
+  'VACATION',
+  'EDUCATION',
+  'HOME',
+  'RETIREMENT',
+  'CUSTOM',
+])
+
+const goalStatusEnum = z.enum(['ACTIVE', 'COMPLETED', 'ARCHIVED'])
+
+export const createGoalSchema = z.object({
+  title: z.string().min(1, 'Title is required').max(200, 'Title must be 200 characters or less'),
+  description: z
+    .string()
+    .max(1000, 'Description must be 1000 characters or less')
+    .optional(),
+  targetAmount: z
+    .union([z.string(), z.number()])
+    .refine((val) => !isNaN(Number(val)) && Number(val) > 0, {
+      message: 'Target amount must be a positive number',
+    }),
+  deadline: z
+    .string()
+    .refine((val) => !isNaN(Date.parse(val)), { message: 'Invalid deadline date' }),
+  category: goalCategoryEnum,
+  isPublic: z.boolean().optional().default(false),
+})
+
+export const updateGoalSchema = z.object({
+  title: z
+    .string()
+    .min(1, 'Title cannot be empty')
+    .max(200, 'Title must be 200 characters or less')
+    .optional(),
+  description: z
+    .string()
+    .max(1000, 'Description must be 1000 characters or less')
+    .optional(),
+  targetAmount: z
+    .union([z.string(), z.number()])
+    .refine((val) => !isNaN(Number(val)) && Number(val) > 0, {
+      message: 'Target amount must be a positive number',
+    })
+    .optional(),
+  deadline: z
+    .string()
+    .refine((val) => !isNaN(Date.parse(val)), { message: 'Invalid deadline date' })
+    .optional(),
+  category: goalCategoryEnum.optional(),
+  isPublic: z.boolean().optional(),
+  status: goalStatusEnum.optional(),
+})
+
+export const affordabilitySchema = z.object({
+  monthlyIncome: z.number().positive('Monthly income must be positive'),
+  monthlyExpenses: z.number().min(0, 'Monthly expenses cannot be negative'),
+  goalTarget: z.number().positive('Goal target must be positive'),
+  goalDeadline: z
+    .string()
+    .refine((val) => !isNaN(Date.parse(val)), { message: 'Invalid goal deadline date' }),
+})
+
+export const projectionSchema = z.object({
+  principal: z.number().min(0, 'Principal cannot be negative'),
+  monthlyContribution: z.number().min(0, 'Monthly contribution cannot be negative'),
+  interestRate: z.number().min(0, 'Interest rate cannot be negative').max(100, 'Interest rate cannot exceed 100'),
+  years: z.number().positive('Years must be positive').max(100, 'Years cannot exceed 100'),
+})
+
+export const goalIdParamSchema = idParamSchema
+
+export type CreateGoalInput = z.infer<typeof createGoalSchema>
+export type UpdateGoalInput = z.infer<typeof updateGoalSchema>
+export type AffordabilityInput = z.infer<typeof affordabilitySchema>
+export type ProjectionInput = z.infer<typeof projectionSchema>

--- a/backend/src/schemas/group.schema.ts
+++ b/backend/src/schemas/group.schema.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod'
+import { stellarPublicKeySchema, paginationSchema, idParamSchema } from './common.schema'
+
+export const createGroupSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'Group name is required')
+    .max(100, 'Group name must be 100 characters or less'),
+  description: z.string().max(500, 'Description must be 500 characters or less').optional(),
+  contributionAmount: z
+    .string()
+    .refine((val) => !isNaN(Number(val)) && Number(val) > 0, {
+      message: 'Contribution amount must be a positive number',
+    }),
+  frequency: z.string().min(1, 'Frequency is required'),
+  maxMembers: z
+    .number()
+    .int('Max members must be an integer')
+    .min(2, 'Max members must be at least 2')
+    .max(100, 'Max members cannot exceed 100'),
+  currentMembers: z
+    .number()
+    .int('Current members must be an integer')
+    .min(0, 'Current members cannot be negative')
+    .max(100, 'Current members cannot exceed 100'),
+  adminPublicKey: stellarPublicKeySchema,
+})
+
+export const joinGroupSchema = z.object({
+  publicKey: stellarPublicKeySchema,
+  signedXdr: z.string().optional(),
+})
+
+export const contributeSchema = z.object({
+  amount: z
+    .string()
+    .refine((val) => !isNaN(Number(val)) && Number(val) > 0, {
+      message: 'Amount must be a positive number',
+    }),
+  publicKey: stellarPublicKeySchema,
+  signedXdr: z.string().optional(),
+})
+
+export const groupIdParamSchema = idParamSchema
+
+export const groupPaginationQuerySchema = paginationSchema
+
+export type CreateGroupInput = z.infer<typeof createGroupSchema>
+export type JoinGroupInput = z.infer<typeof joinGroupSchema>
+export type ContributeInput = z.infer<typeof contributeSchema>

--- a/backend/src/schemas/reward.schema.ts
+++ b/backend/src/schemas/reward.schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod'
+import { idParamSchema, offsetPaginationSchema } from './common.schema'
+
+const rewardStatusEnum = z.enum(['PENDING', 'ACTIVE', 'REDEEMED', 'EXPIRED'])
+const rewardTypeEnum = z.enum(['POINTS', 'BADGE', 'CASHBACK', 'DISCOUNT', 'BONUS'])
+
+export const rewardQuerySchema = offsetPaginationSchema.extend({
+  status: rewardStatusEnum.optional(),
+  type: rewardTypeEnum.optional(),
+})
+
+export const rewardIdParamSchema = idParamSchema
+
+export type RewardQuery = z.infer<typeof rewardQuerySchema>
+export type RewardIdParam = z.infer<typeof rewardIdParamSchema>

--- a/backend/src/schemas/user.schema.ts
+++ b/backend/src/schemas/user.schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+import { stellarPublicKeySchema } from './common.schema'
+
+export const updateUserProfileSchema = z.object({
+  displayName: z
+    .string()
+    .min(1, 'Display name cannot be empty')
+    .max(100, 'Display name must be 100 characters or less')
+    .optional(),
+  email: z.string().email('Invalid email address').optional(),
+  avatarUrl: z.string().url('Invalid avatar URL').optional(),
+  bio: z.string().max(500, 'Bio must be 500 characters or less').optional(),
+})
+
+export const walletAddressParamSchema = z.object({
+  walletAddress: stellarPublicKeySchema,
+})
+
+export type UpdateUserProfileInput = z.infer<typeof updateUserProfileSchema>
+export type WalletAddressParam = z.infer<typeof walletAddressParamSchema>

--- a/backend/src/utils/zodHelpers.ts
+++ b/backend/src/utils/zodHelpers.ts
@@ -1,0 +1,35 @@
+import { ZodError, ZodSchema } from 'zod'
+
+/**
+ * Formats Zod validation errors into a consistent shape.
+ */
+export function formatZodErrors(error: ZodError) {
+  return error.errors.map((err) => ({
+    field: err.path.join('.'),
+    message: err.message,
+    code: err.code,
+  }))
+}
+
+/**
+ * Safe parse that returns a typed result instead of throwing.
+ */
+export function safeParse<T>(
+  schema: ZodSchema<T>,
+  data: unknown
+): { success: true; data: T } | { success: false; errors: ReturnType<typeof formatZodErrors> } {
+  const result = schema.safeParse(data)
+  if (result.success) {
+    return { success: true, data: result.data }
+  }
+  return { success: false, errors: formatZodErrors(result.error) }
+}
+
+/**
+ * Strips undefined values from an object (useful before DB updates).
+ */
+export function stripUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, v]) => v !== undefined)
+  ) as Partial<T>
+}


### PR DESCRIPTION
Created backend/src/schemas/ with 6 schema files (common, auth, goal, group, user, reward) and 
zodHelpers.ts
. Updated validateRequest.ts to unify both middleware variants into one with a validate alias. Wired validation middleware into goals.ts, auth.ts, and rewards.ts routes, and cleaned up goalsController.ts to remove inline schemas in favor of route-level validation.

Close #326 