### PR TITLE
feat: convert app to PWA with offline support, installability, and pu…

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,3 +6,8 @@ NEXT_PUBLIC_SOROBAN_CONTRACT_ID=your_contract_id_here
 # Application Configuration
 NEXT_PUBLIC_APP_NAME=Ajo
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# PWA Push Notifications (generate with: npx web-push generate-vapid-keys)
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=your_vapid_public_key_here
+VAPID_PRIVATE_KEY=your_vapid_private_key_here
+VAPID_SUBJECT=mailto:admin@ajo.app

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -7,6 +7,8 @@ const withPWA =
         dest: 'public',
         register: true,
         skipWaiting: true,
+        customWorkerDir: 'public',
+        customWorkerSrc: 'sw-custom.js',
         runtimeCaching: [
           {
             urlPattern: /^https:\/\/fonts\.(?:gstatic)\.com\/.*/i,

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,24 +1,41 @@
 {
+  "id": "/",
   "name": "Ajo - Decentralized Savings Groups",
   "short_name": "Ajo",
   "description": "Join and manage savings groups on the Stellar blockchain",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
+  "display_override": ["window-controls-overlay", "standalone", "minimal-ui"],
   "background_color": "#ffffff",
   "theme_color": "#3b82f6",
   "orientation": "portrait-primary",
+  "lang": "en",
+  "dir": "ltr",
   "icons": [
     {
       "src": "/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "/apple-touch-icon.png",
@@ -27,6 +44,15 @@
     }
   ],
   "categories": ["finance", "productivity"],
+  "screenshots": [
+    {
+      "src": "/og-image.png",
+      "sizes": "1200x630",
+      "type": "image/png",
+      "form_factor": "wide",
+      "label": "Ajo Dashboard"
+    }
+  ],
   "shortcuts": [
     {
       "name": "Dashboard",
@@ -42,5 +68,6 @@
       "url": "/groups/create",
       "icons": [{ "src": "/icon-192.png", "sizes": "192x192" }]
     }
-  ]
+  ],
+  "prefer_related_applications": false
 }

--- a/frontend/public/sw-custom.js
+++ b/frontend/public/sw-custom.js
@@ -1,0 +1,86 @@
+/**
+ * Custom Service Worker for Ajo PWA
+ * Handles push notifications and background sync.
+ * next-pwa merges this with the generated sw.js via importScripts.
+ */
+
+// ─── Push Notifications ───────────────────────────────────────────────────────
+
+self.addEventListener('push', (event) => {
+  if (!event.data) return;
+
+  let data;
+  try {
+    data = event.data.json();
+  } catch {
+    data = { title: 'Ajo', body: event.data.text() };
+  }
+
+  const { title = 'Ajo', body = '', icon = '/icon-192.png', badge = '/icon-192.png', url = '/', tag, data: extraData } = data;
+
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      icon,
+      badge,
+      tag: tag || 'ajo-notification',
+      data: { url, ...extraData },
+      vibrate: [200, 100, 200],
+      requireInteraction: false,
+    })
+  );
+});
+
+// ─── Notification Click ───────────────────────────────────────────────────────
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/';
+
+  event.waitUntil(
+    clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((windowClients) => {
+        // Focus existing window if already open
+        for (const client of windowClients) {
+          if (client.url.includes(self.location.origin) && 'focus' in client) {
+            client.navigate(targetUrl);
+            return client.focus();
+          }
+        }
+        // Otherwise open a new window
+        if (clients.openWindow) {
+          return clients.openWindow(targetUrl);
+        }
+      })
+  );
+});
+
+// ─── Background Sync ─────────────────────────────────────────────────────────
+
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'sync-contributions') {
+    event.waitUntil(syncPendingContributions());
+  }
+});
+
+async function syncPendingContributions() {
+  try {
+    const cache = await caches.open('ajo-pending-actions');
+    const keys = await cache.keys();
+    for (const request of keys) {
+      const response = await cache.match(request);
+      if (!response) continue;
+      const body = await response.json();
+      await fetch(request, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      await cache.delete(request);
+    }
+  } catch {
+    // Will retry on next sync
+  }
+}

--- a/frontend/src/components/NotificationPreferences.tsx
+++ b/frontend/src/components/NotificationPreferences.tsx
@@ -1,47 +1,35 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { useNotifications } from '@/hooks/useNotifications';
-import { subscribeToPushNotifications, unsubscribeFromPushNotifications, requestNotificationPermission } from '@/services/pushNotifications';
-import { Bell, Mail, Smartphone, Check } from 'lucide-react';
+import { usePushNotifications } from '@/hooks/usePushNotifications';
+import { Bell, Mail, Smartphone, Check, Loader2 } from 'lucide-react';
 import toast from 'react-hot-toast';
 
 export default function NotificationPreferences() {
-  const { preferences, updatePreferences, setPushSubscription } = useNotifications();
-  const [pushEnabled, setPushEnabled] = useState(false);
-  const [pushPermission, setPushPermission] = useState<NotificationPermission>('default');
-
-  useEffect(() => {
-    if ('Notification' in window) {
-      setPushPermission(Notification.permission);
-    }
-  }, []);
+  const { preferences, updatePreferences } = useNotifications();
+  const { status, isSubscribed, isLoading, subscribe, unsubscribe } = usePushNotifications();
 
   const handlePushToggle = async () => {
-    if (!pushEnabled) {
-      const permission = await requestNotificationPermission();
-      setPushPermission(permission);
-
-      if (permission === 'granted') {
-        const subscription = await subscribeToPushNotifications();
-        if (subscription) {
-          setPushSubscription(subscription);
-          setPushEnabled(true);
-          updatePreferences({ push: true });
-          toast.success('Push notifications enabled');
-        } else {
-          toast.error('Failed to enable push notifications');
-        }
-      } else {
-        toast.error('Notification permission denied');
-      }
-    } else {
-      const success = await unsubscribeFromPushNotifications();
-      if (success) {
-        setPushSubscription(null);
-        setPushEnabled(false);
+    if (isSubscribed) {
+      const ok = await unsubscribe();
+      if (ok) {
         updatePreferences({ push: false });
         toast.success('Push notifications disabled');
+      } else {
+        toast.error('Failed to disable push notifications');
+      }
+    } else {
+      if (status === 'denied') {
+        toast.error('Permission denied – enable notifications in browser settings');
+        return;
+      }
+      const ok = await subscribe();
+      if (ok) {
+        updatePreferences({ push: true });
+        toast.success('Push notifications enabled');
+      } else {
+        toast.error('Failed to enable push notifications');
       }
     }
   };
@@ -69,18 +57,15 @@ export default function NotificationPreferences() {
           </h4>
 
           <div className="space-y-3">
+            {/* In-App */}
             <label className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer">
               <div className="flex items-center gap-3">
                 <div className="w-10 h-10 rounded-full bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
                   <Bell className="w-5 h-5 text-blue-600 dark:text-blue-400" />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-gray-900 dark:text-white">
-                    In-App Notifications
-                  </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
-                    Show notifications in the app
-                  </p>
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">In-App Notifications</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">Show notifications in the app</p>
                 </div>
               </div>
               <input
@@ -91,49 +76,52 @@ export default function NotificationPreferences() {
               />
             </label>
 
-            <label className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer">
+            {/* Push */}
+            <div className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50">
               <div className="flex items-center gap-3">
                 <div className="w-10 h-10 rounded-full bg-purple-100 dark:bg-purple-900/30 flex items-center justify-center">
                   <Smartphone className="w-5 h-5 text-purple-600 dark:text-purple-400" />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-gray-900 dark:text-white">
-                    Push Notifications
-                  </p>
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">Push Notifications</p>
                   <p className="text-xs text-gray-500 dark:text-gray-400">
-                    {pushPermission === 'denied'
-                      ? 'Permission denied - enable in browser settings'
+                    {status === 'unsupported'
+                      ? 'Not supported in this browser'
+                      : status === 'denied'
+                      ? 'Permission denied – enable in browser settings'
                       : 'Receive browser push notifications'}
                   </p>
                 </div>
               </div>
               <button
                 onClick={handlePushToggle}
-                disabled={pushPermission === 'denied'}
-                className={`w-12 h-6 rounded-full transition-colors relative ${
-                  pushEnabled ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
-                } ${pushPermission === 'denied' ? 'opacity-50 cursor-not-allowed' : ''}`}
+                disabled={isLoading || status === 'unsupported' || status === 'denied'}
+                aria-label={isSubscribed ? 'Disable push notifications' : 'Enable push notifications'}
+                className={`w-12 h-6 rounded-full transition-colors relative flex-shrink-0 ${
+                  isSubscribed ? 'bg-blue-600' : 'bg-gray-300 dark:bg-gray-600'
+                } ${isLoading || status === 'unsupported' || status === 'denied' ? 'opacity-50 cursor-not-allowed' : ''}`}
               >
-                <span
-                  className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
-                    pushEnabled ? 'translate-x-6' : ''
-                  }`}
-                />
+                {isLoading ? (
+                  <Loader2 className="absolute inset-0 m-auto w-4 h-4 text-white animate-spin" />
+                ) : (
+                  <span
+                    className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full transition-transform ${
+                      isSubscribed ? 'translate-x-6' : ''
+                    }`}
+                  />
+                )}
               </button>
-            </label>
+            </div>
 
+            {/* Email */}
             <label className="flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer">
               <div className="flex items-center gap-3">
                 <div className="w-10 h-10 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center">
                   <Mail className="w-5 h-5 text-green-600 dark:text-green-400" />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-gray-900 dark:text-white">
-                    Email Notifications
-                  </p>
-                  <p className="text-xs text-gray-500 dark:text-gray-400">
-                    Receive notifications via email
-                  </p>
+                  <p className="text-sm font-medium text-gray-900 dark:text-white">Email Notifications</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">Receive notifications via email</p>
                 </div>
               </div>
               <input
@@ -148,10 +136,7 @@ export default function NotificationPreferences() {
 
         {/* Notification Types */}
         <div className="p-4">
-          <h4 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">
-            Notification Types
-          </h4>
-
+          <h4 className="text-sm font-semibold text-gray-900 dark:text-white mb-3">Notification Types</h4>
           <div className="space-y-2">
             {[
               { key: 'contributionDue24h', label: 'Contribution due in 24 hours', icon: '⏰' },
@@ -168,9 +153,7 @@ export default function NotificationPreferences() {
               >
                 <div className="flex items-center gap-2">
                   <span className="text-lg">{item.icon}</span>
-                  <span className="text-sm text-gray-700 dark:text-gray-300">
-                    {item.label}
-                  </span>
+                  <span className="text-sm text-gray-700 dark:text-gray-300">{item.label}</span>
                 </div>
                 <input
                   type="checkbox"

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -2,3 +2,5 @@
 export { useTableState } from './useTableState'
 export type { TableFilters, UseTableStateOptions, UseTableStateReturn } from './useTableState'
 export { useSkeletonDelay } from './useSkeletonDelay'
+export { usePushNotifications } from './usePushNotifications'
+export type { PushStatus } from './usePushNotifications'

--- a/frontend/src/hooks/usePushNotifications.ts
+++ b/frontend/src/hooks/usePushNotifications.ts
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import {
+  registerServiceWorker,
+  requestNotificationPermission,
+  subscribeToPushNotifications,
+  unsubscribeFromPushNotifications,
+} from '@/services/pushNotifications';
+import { useNotifications } from './useNotifications';
+
+export type PushStatus = 'unsupported' | 'default' | 'granted' | 'denied';
+
+interface UsePushNotificationsReturn {
+  status: PushStatus;
+  isSubscribed: boolean;
+  isLoading: boolean;
+  subscribe: () => Promise<boolean>;
+  unsubscribe: () => Promise<boolean>;
+}
+
+export function usePushNotifications(): UsePushNotificationsReturn {
+  const { setPushSubscription } = useNotifications();
+  const [status, setStatus] = useState<PushStatus>('default');
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Initialise state from browser on mount
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    if (!('Notification' in window) || !('serviceWorker' in navigator)) {
+      setStatus('unsupported');
+      return;
+    }
+
+    setStatus(Notification.permission as PushStatus);
+
+    // Check if already subscribed
+    navigator.serviceWorker.ready
+      .then((reg) => reg.pushManager.getSubscription())
+      .then((sub) => {
+        if (sub) {
+          setIsSubscribed(true);
+          setPushSubscription(sub);
+        }
+      })
+      .catch(() => {});
+  }, [setPushSubscription]);
+
+  const subscribe = useCallback(async (): Promise<boolean> => {
+    setIsLoading(true);
+    try {
+      await registerServiceWorker();
+      const permission = await requestNotificationPermission();
+      setStatus(permission as PushStatus);
+
+      if (permission !== 'granted') return false;
+
+      const subscription = await subscribeToPushNotifications();
+      if (!subscription) return false;
+
+      setPushSubscription(subscription);
+      setIsSubscribed(true);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [setPushSubscription]);
+
+  const unsubscribe = useCallback(async (): Promise<boolean> => {
+    setIsLoading(true);
+    try {
+      const success = await unsubscribeFromPushNotifications();
+      if (success) {
+        setPushSubscription(null);
+        setIsSubscribed(false);
+      }
+      return success;
+    } catch {
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [setPushSubscription]);
+
+  return { status, isSubscribed, isLoading, subscribe, unsubscribe };
+}


### PR DESCRIPTION
Completes the PWA implementation for the Ajo frontend — adding a functional service worker with push notification handling, background sync, a dedicated hook for the push subscription lifecycle, and an improved web app manifest for full installability.

What changed
sw-custom.js
 — new custom service worker merged into the next-pwa-generated sw.js at build time. Handles three events:

push — receives server-sent push payloads and calls showNotification with icon, badge, vibration, and a deep-link URL
notificationclick — focuses an existing app window or opens a new one at the notification's target URL
sync — replays any pending contribution requests stored in the ajo-pending-actions cache when connectivity is restored
usePushNotifications.ts
 — new hook that owns the full push subscription lifecycle: SW registration, permission request, subscribe/unsubscribe, and hydrating existing subscription state on mount. Exposes { status, isSubscribed, isLoading, subscribe, unsubscribe }.

NotificationPreferences.tsx
 — refactored to consume usePushNotifications. Adds a loading spinner during async operations and correctly disables the toggle when the API is unsupported or permission is denied.

next.config.js — added customWorkerDir and customWorkerSrc so next-pwa merges sw-custom.js into the generated service worker.

manifest.json
 — enhanced for better installability:

Added id field (required for identity-based install prompts)
Added display_override: ["window-controls-overlay", ...]
Split icon entries into separate any and maskable purposes
Added screenshots for richer install UI on Android/desktop
.env.example — documents the three VAPID env vars required for push (NEXT_PUBLIC_VAPID_PUBLIC_KEY, VAPID_PRIVATE_KEY, VAPID_SUBJECT). Generate keys with npx web-push generate-vapid-keys.

Testing
Run a production build: npm run build && npm start
Open DevTools → Application → Service Workers — confirm sw.js is registered and active
Application → Manifest — verify all fields and icons resolve correctly
Application → Push Messaging — send a test push and confirm the notification appears and clicking it navigates to the correct route
Go offline (DevTools → Network → Offline) — confirm the /offline fallback page loads and the OfflineIndicator banner appears
Re-connect — confirm the back-online banner shows and background sync fires
Notes
The custom SW is only bundled in production builds. next dev bypasses next-pwa entirely, so push/sync won't work locally without a production build.
A VAPID key pair must be set in .env before push subscriptions will work end-to-end. The backend will need to use VAPID_PRIVATE_KEY when sending push messages via web-push.

close #371 