### PR TITLE
feat: email notification preferences per event type

### DIFF
--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -165,7 +165,7 @@ export default function ProfilePage() {
             )}
 
             {activeSection === 'settings' && (
-              <SettingsPanel preferences={profile.preferences} onSave={updatePreferences} isLoading={loading} />
+              <SettingsPanel preferences={profile.preferences} onSave={updatePreferences} isLoading={loading} email={profile.email} />
             )}
 
             {activeSection === 'activity' && (

--- a/frontend/src/components/EmailNotificationPreferences.tsx
+++ b/frontend/src/components/EmailNotificationPreferences.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import React from 'react'
+import { Mail, ShieldAlert, Info } from 'lucide-react'
+import type {
+  EmailNotificationPreferences as EmailPrefs,
+  EmailFrequency,
+} from '@/types/profile'
+import { defaultEmailPreferences } from '@/types/profile'
+
+interface Props {
+  value: EmailPrefs | undefined
+  onChange: (value: EmailPrefs) => void
+  /** User's verified email address — shown as context */
+  email?: string
+}
+
+// ─── Event definitions ────────────────────────────────────────────────────────
+
+type EventKey = keyof EmailPrefs['events']
+
+interface EventDef {
+  key: EventKey
+  label: string
+  description: string
+  icon: string
+  category: 'contributions' | 'groups' | 'account'
+}
+
+const EVENT_DEFS: EventDef[] = [
+  // Contributions
+  { key: 'contributionDue24h',  label: 'Contribution due in 24 hours', description: 'Reminder the day before your contribution is due',       icon: '⏰', category: 'contributions' },
+  { key: 'contributionDue1h',   label: 'Contribution due in 1 hour',   description: 'Last-minute reminder before your contribution is due',   icon: '⚡', category: 'contributions' },
+  { key: 'contributionOverdue', label: 'Contribution overdue',         description: 'Alert when a contribution deadline has passed',          icon: '⚠️', category: 'contributions' },
+  { key: 'payoutReceived',      label: 'Payout received',              description: 'Confirmation when you receive a group payout',           icon: '💰', category: 'contributions' },
+  // Groups
+  { key: 'memberJoined',        label: 'New member joined',            description: 'When someone joins one of your groups',                  icon: '👥', category: 'groups' },
+  { key: 'cycleCompleted',      label: 'Cycle completed',              description: 'When a group savings cycle finishes',                    icon: '✅', category: 'groups' },
+  { key: 'announcements',       label: 'Group announcements',          description: 'Messages posted by group admins',                        icon: '📢', category: 'groups' },
+  { key: 'groupInvitation',     label: 'Group invitation',             description: 'When you are invited to join a savings group',           icon: '✉️', category: 'groups' },
+  // Account
+  { key: 'securityAlerts',      label: 'Security alerts',              description: 'Important account security notifications (recommended)', icon: '🔒', category: 'account' },
+]
+
+const CATEGORIES: { id: EventDef['category']; label: string }[] = [
+  { id: 'contributions', label: 'Contributions' },
+  { id: 'groups',        label: 'Groups' },
+  { id: 'account',       label: 'Account' },
+]
+
+const FREQUENCY_OPTIONS: { value: EmailFrequency; label: string; description: string }[] = [
+  { value: 'instant', label: 'Instant',       description: 'Send each email as events happen' },
+  { value: 'daily',   label: 'Daily digest',  description: 'Bundle all events into one daily email' },
+  { value: 'weekly',  label: 'Weekly digest', description: 'Bundle all events into one weekly email' },
+]
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function Toggle({ checked, onChange, disabled }: { checked: boolean; onChange: () => void; disabled?: boolean }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={onChange}
+      disabled={disabled}
+      className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 ${
+        checked ? 'bg-blue-600 dark:bg-indigo-500' : 'bg-gray-300 dark:bg-slate-600'
+      } ${disabled ? 'opacity-40 cursor-not-allowed' : 'cursor-pointer'}`}
+    >
+      <span
+        className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+          checked ? 'translate-x-6' : 'translate-x-1'
+        }`}
+      />
+    </button>
+  )
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function EmailNotificationPreferences({ value, onChange, email }: Props) {
+  const prefs: EmailPrefs = value ?? defaultEmailPreferences
+
+  const update = (patch: Partial<EmailPrefs>) => onChange({ ...prefs, ...patch })
+
+  const toggleEvent = (key: EventKey) => {
+    // Security alerts cannot be disabled
+    if (key === 'securityAlerts') return
+    update({ events: { ...prefs.events, [key]: !prefs.events[key] } })
+  }
+
+  const allInCategory = (cat: EventDef['category']) =>
+    EVENT_DEFS.filter((e) => e.category === cat && e.key !== 'securityAlerts').every(
+      (e) => prefs.events[e.key]
+    )
+
+  const toggleCategory = (cat: EventDef['category']) => {
+    const keys = EVENT_DEFS.filter((e) => e.category === cat && e.key !== 'securityAlerts').map((e) => e.key)
+    const next = !allInCategory(cat)
+    const patch = Object.fromEntries(keys.map((k) => [k, next])) as Partial<EmailPrefs['events']>
+    update({ events: { ...prefs.events, ...patch } })
+  }
+
+  return (
+    <div className="space-y-6">
+
+      {/* Master toggle + email address */}
+      <div className="flex items-start justify-between gap-4 p-4 bg-gray-50 dark:bg-slate-700/40 rounded-xl border border-gray-200 dark:border-slate-600">
+        <div className="flex items-start gap-3">
+          <div className="w-10 h-10 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center flex-shrink-0">
+            <Mail className="w-5 h-5 text-green-600 dark:text-green-400" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">Email Notifications</p>
+            {email ? (
+              <p className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">
+                Sending to <span className="font-medium text-gray-700 dark:text-slate-300">{email}</span>
+              </p>
+            ) : (
+              <p className="text-xs text-amber-600 dark:text-amber-400 mt-0.5 flex items-center gap-1">
+                <Info className="w-3 h-3" /> Add an email address in your profile to enable
+              </p>
+            )}
+          </div>
+        </div>
+        <Toggle
+          checked={prefs.enabled}
+          onChange={() => update({ enabled: !prefs.enabled })}
+          disabled={!email}
+        />
+      </div>
+
+      {/* Frequency selector */}
+      <div className={prefs.enabled && email ? '' : 'opacity-40 pointer-events-none'}>
+        <p className="text-sm font-semibold text-gray-900 dark:text-slate-100 mb-3">Delivery frequency</p>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {FREQUENCY_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => update({ frequency: opt.value })}
+              className={`text-left p-3 rounded-xl border-2 transition-colors ${
+                prefs.frequency === opt.value
+                  ? 'border-blue-500 dark:border-indigo-400 bg-blue-50 dark:bg-indigo-900/20'
+                  : 'border-gray-200 dark:border-slate-600 hover:border-gray-300 dark:hover:border-slate-500'
+              }`}
+            >
+              <p className={`text-sm font-semibold ${prefs.frequency === opt.value ? 'text-blue-700 dark:text-indigo-300' : 'text-gray-900 dark:text-slate-100'}`}>
+                {opt.label}
+              </p>
+              <p className="text-xs text-gray-500 dark:text-slate-400 mt-0.5">{opt.description}</p>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Per-event toggles grouped by category */}
+      <div className={`space-y-5 ${prefs.enabled && email ? '' : 'opacity-40 pointer-events-none'}`}>
+        <p className="text-sm font-semibold text-gray-900 dark:text-slate-100">Notify me about</p>
+
+        {CATEGORIES.map((cat) => {
+          const events = EVENT_DEFS.filter((e) => e.category === cat.id)
+          const nonSecurity = events.filter((e) => e.key !== 'securityAlerts')
+
+          return (
+            <div key={cat.id} className="bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden">
+              {/* Category header with select-all */}
+              <div className="flex items-center justify-between px-4 py-3 bg-gray-50 dark:bg-slate-700/50 border-b border-gray-200 dark:border-slate-700">
+                <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-slate-400">
+                  {cat.label}
+                </p>
+                {nonSecurity.length > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => toggleCategory(cat.id)}
+                    className="text-xs text-blue-600 dark:text-indigo-400 hover:underline font-medium"
+                  >
+                    {allInCategory(cat.id) ? 'Disable all' : 'Enable all'}
+                  </button>
+                )}
+              </div>
+
+              {/* Events */}
+              <div className="divide-y divide-gray-100 dark:divide-slate-700">
+                {events.map((ev) => (
+                  <div
+                    key={ev.key}
+                    className="flex items-center justify-between px-4 py-3 hover:bg-gray-50 dark:hover:bg-slate-700/30 transition-colors"
+                  >
+                    <div className="flex items-center gap-3 min-w-0">
+                      <span className="text-base flex-shrink-0">{ev.icon}</span>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-gray-900 dark:text-slate-100 flex items-center gap-1.5">
+                          {ev.label}
+                          {ev.key === 'securityAlerts' && (
+                            <span className="inline-flex items-center gap-0.5 text-xs text-amber-600 dark:text-amber-400">
+                              <ShieldAlert className="w-3 h-3" /> always on
+                            </span>
+                          )}
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-slate-400 truncate">{ev.description}</p>
+                      </div>
+                    </div>
+                    <Toggle
+                      checked={prefs.events[ev.key]}
+                      onChange={() => toggleEvent(ev.key)}
+                      disabled={ev.key === 'securityAlerts'}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+    </div>
+  )
+}

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -5,14 +5,18 @@ import toast from 'react-hot-toast'
 import { useTheme } from '@/context/ThemeContext'
 import { useOnboarding } from '@/hooks/useOnboarding'
 import type { UserPreferences } from '@/types/profile'
+import { defaultEmailPreferences } from '@/types/profile'
+import { EmailNotificationPreferences } from '@/components/EmailNotificationPreferences'
 
 interface SettingsPanelProps {
   preferences: UserPreferences
   onSave: (preferences: Partial<UserPreferences>) => Promise<void>
   isLoading?: boolean
+  /** User's verified email address, passed through to EmailNotificationPreferences */
+  email?: string
 }
 
-export const SettingsPanel: React.FC<SettingsPanelProps> = ({ preferences, onSave, isLoading = false }) => {
+export const SettingsPanel: React.FC<SettingsPanelProps> = ({ preferences, onSave, isLoading = false, email }) => {
   const { setTheme } = useTheme()
   const { replayTutorial } = useOnboarding()
   const [activeTab, setActiveTab] = useState<'notifications' | 'privacy' | 'display'>('notifications')
@@ -110,16 +114,11 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ preferences, onSav
       <div className="p-8">
         {/* Notifications Tab */}
         {activeTab === 'notifications' && (
-          <div className="space-y-6">
+          <div className="space-y-8">
+            {/* General channel toggles */}
             <div>
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-4">Notification Preferences</h3>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-4">Notification Channels</h3>
               <div className="space-y-4">
-                <ToggleItem
-                  label="Email Notifications"
-                  description="Receive updates via email"
-                  checked={localPreferences.notifications.email}
-                  onChange={() => handleToggle('notifications', 'email')}
-                />
                 <ToggleItem
                   label="Push Notifications"
                   description="Receive browser push notifications"
@@ -145,6 +144,21 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ preferences, onSav
                   onChange={() => handleToggle('notifications', 'contributionReminders')}
                 />
               </div>
+            </div>
+
+            {/* Granular email preferences */}
+            <div className="pt-6 border-t border-gray-200 dark:border-slate-700">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-slate-100 mb-1">Email Notifications</h3>
+              <p className="text-sm text-gray-500 dark:text-slate-400 mb-6">
+                Choose which events trigger an email and how often to receive them.
+              </p>
+              <EmailNotificationPreferences
+                value={localPreferences.emailNotifications ?? defaultEmailPreferences}
+                onChange={(emailPrefs) =>
+                  setLocalPreferences((prev) => ({ ...prev, emailNotifications: emailPrefs }))
+                }
+                email={email}
+              />
             </div>
           </div>
         )}

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -22,6 +22,21 @@ export interface UserPreferences {
   theme: 'light' | 'dark' | 'auto'
   language: string
   currency: string
+  emailNotifications?: {
+    enabled: boolean
+    frequency: 'instant' | 'daily' | 'weekly'
+    events: {
+      contributionDue24h: boolean
+      contributionDue1h: boolean
+      contributionOverdue: boolean
+      payoutReceived: boolean
+      memberJoined: boolean
+      cycleCompleted: boolean
+      announcements: boolean
+      groupInvitation: boolean
+      securityAlerts: boolean
+    }
+  }
 }
 
 export interface UserStats {

--- a/frontend/src/services/profileService.ts
+++ b/frontend/src/services/profileService.ts
@@ -80,11 +80,38 @@ export class ProfileService {
         address,
         joinedDate: new Date().toISOString(),
         preferences: {
-          notifications: true,
-          emailUpdates: false,
-          theme: 'auto',
-          language: 'en',
-          currency: 'USD',
+          notifications: {
+            email: false,
+            push: true,
+            groupUpdates: true,
+            payoutReminders: true,
+            contributionReminders: true,
+          },
+          emailNotifications: {
+            enabled: false,
+            frequency: 'instant',
+            events: {
+              contributionDue24h: true,
+              contributionDue1h: false,
+              contributionOverdue: true,
+              payoutReceived: true,
+              memberJoined: false,
+              cycleCompleted: true,
+              announcements: false,
+              groupInvitation: true,
+              securityAlerts: true,
+            },
+          },
+          privacy: {
+            showProfile: true,
+            showActivity: true,
+            showStats: true,
+          },
+          display: {
+            theme: 'auto',
+            language: 'en',
+            currency: 'USD',
+          },
         },
         stats: {
           totalGroups: 0,

--- a/frontend/src/types/profile.ts
+++ b/frontend/src/types/profile.ts
@@ -9,6 +9,43 @@ export interface UserProfile {
   stats: UserStats
 }
 
+export type EmailFrequency = 'instant' | 'daily' | 'weekly'
+
+export interface EmailNotificationPreferences {
+  /** Master switch — when false all email notifications are suppressed */
+  enabled: boolean
+  /** How often to batch and send emails */
+  frequency: EmailFrequency
+  /** Per-event-type toggles */
+  events: {
+    contributionDue24h: boolean
+    contributionDue1h: boolean
+    contributionOverdue: boolean
+    payoutReceived: boolean
+    memberJoined: boolean
+    cycleCompleted: boolean
+    announcements: boolean
+    groupInvitation: boolean
+    securityAlerts: boolean
+  }
+}
+
+export const defaultEmailPreferences: EmailNotificationPreferences = {
+  enabled: false,
+  frequency: 'instant',
+  events: {
+    contributionDue24h: true,
+    contributionDue1h: false,
+    contributionOverdue: true,
+    payoutReceived: true,
+    memberJoined: false,
+    cycleCompleted: true,
+    announcements: false,
+    groupInvitation: true,
+    securityAlerts: true,
+  },
+}
+
 export interface UserPreferences {
   notifications: {
     email: boolean
@@ -17,6 +54,7 @@ export interface UserPreferences {
     payoutReminders: boolean
     contributionReminders: boolean
   }
+  emailNotifications: EmailNotificationPreferences
   privacy: {
     showProfile: boolean
     showActivity: boolean


### PR DESCRIPTION
Summary
Replaces the single "Email Notifications" on/off toggle in the settings panel with a full per-event configuration UI. Users can now choose exactly which events trigger an email, how often emails are delivered, and see which address they're sending to — all from the Profile → Settings → Notifications tab.

What changed
EmailNotificationPreferences.tsx
 — new self-contained component with three sections:

Master toggle — enables/disables all email notifications. Disabled and shows a hint when no email address is set on the profile.
Delivery frequency — card-style picker for instant, daily digest, or weekly digest. The entire event section dims when the master toggle is off.
Per-event toggles — 9 events grouped into three categories:
Category	Events
Contributions	Contribution due 24h, due 1h, overdue, payout received
Groups	Member joined, cycle completed, announcements, group invitation
Account	Security alerts (always on, cannot be disabled)
Each category has an "enable all / disable all" shortcut. Security alerts show a shield badge and their toggle is permanently locked.

profile.ts
 — extended with:

EmailNotificationPreferences interface (master enabled, frequency, and events map)
EmailFrequency union type ('instant' | 'daily' | 'weekly')
defaultEmailPreferences export — shared default used by both the component and profile creation
SettingsPanel.tsx
 — notifications tab updated:

Removed the old flat "Email Notifications" toggle
Added the EmailNotificationPreferences component below the existing push/group/payout toggles
Accepts a new optional email prop, passed through to show the destination address and gate the master toggle
page.tsx
 — passes profile.email to SettingsPanel

useProfile.ts
 — UserPreferences extended with optional emailNotifications field

profileService.ts
 — new profiles are initialised with sensible defaults: master off, security alerts always on, contribution overdue / payout received / group invitation / cycle completed pre-enabled

Behaviour notes
The master toggle is disabled when the user has no email address on their profile. A contextual hint directs them to add one.
Security alerts cannot be toggled off — they are always delivered regardless of other settings.
Preferences are persisted via the existing updatePreferences flow (localStorage → profile store) and saved with the rest of the settings panel on "Save Changes".
defaultEmailPreferences is exported from 
profile.ts
 so any future backend sync or form reset has a single source of truth.
Testing
Go to Profile → Settings → Notifications
Confirm the email section renders below the push/group toggles
With no email on the profile — confirm the master toggle is disabled and the hint is shown
Add an email to the profile, return to settings — confirm the master toggle is now active
Enable email notifications, change frequency to "Daily digest", disable "Member joined" and "Announcements"
Save — reload the page and confirm preferences are persisted
Confirm security alerts toggle is locked and shows the "always on" badge
Use "Disable all" on the Contributions category — confirm all contribution events toggle off except security alerts
Toggle master off — confirm the frequency picker and event list dim and become non-interactive

close #376 