### PR TITLE
feat(frontend): add member profile cards

### DIFF
--- a/frontend/src/components/ContributionTimeline.tsx
+++ b/frontend/src/components/ContributionTimeline.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import React from 'react'
+import type { ContributionEntry } from '@/hooks/useMemberStats'
+import { getRelativeTime } from '@/utils/avatarUtils'
+
+interface ContributionTimelineProps {
+  contributions: ContributionEntry[]
+  isLoading?: boolean
+}
+
+const statusConfig = {
+  confirmed: {
+    dot: 'bg-emerald-500',
+    label: 'Confirmed',
+    text: 'text-emerald-600 dark:text-emerald-400',
+  },
+  pending: {
+    dot: 'bg-amber-400',
+    label: 'Pending',
+    text: 'text-amber-600 dark:text-amber-400',
+  },
+  failed: {
+    dot: 'bg-red-500',
+    label: 'Failed',
+    text: 'text-red-600 dark:text-red-400',
+  },
+}
+
+export const ContributionTimeline: React.FC<ContributionTimelineProps> = ({
+  contributions,
+  isLoading = false,
+}) => {
+  if (isLoading) {
+    return (
+      <div className="space-y-3" aria-busy="true" aria-label="Loading contribution history">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="flex items-start gap-3">
+            <div className="skeleton w-2.5 h-2.5 rounded-full mt-1.5 flex-shrink-0" />
+            <div className="flex-1 space-y-1.5">
+              <div className="skeleton h-3.5 w-24 rounded" />
+              <div className="skeleton h-3 w-16 rounded" />
+            </div>
+            <div className="skeleton h-3.5 w-14 rounded" />
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (contributions.length === 0) {
+    return (
+      <p className="text-sm text-surface-400 dark:text-slate-500 italic py-2">
+        No contributions yet
+      </p>
+    )
+  }
+
+  const recent = contributions.slice(-5).reverse()
+
+  return (
+    <ol className="relative space-y-0" aria-label="Contribution history">
+      {recent.map((entry, i) => {
+        const cfg = statusConfig[entry.status]
+        return (
+          <li key={i} className="flex items-start gap-3 group">
+            {/* Timeline line + dot */}
+            <div className="flex flex-col items-center flex-shrink-0">
+              <span className={`w-2.5 h-2.5 rounded-full mt-1.5 ring-2 ring-white dark:ring-slate-800 ${cfg.dot}`} />
+              {i < recent.length - 1 && (
+                <span className="w-px flex-1 bg-surface-200 dark:bg-slate-700 my-1 min-h-[20px]" />
+              )}
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 pb-3 min-w-0">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-sm font-semibold text-surface-900 dark:text-slate-100">
+                  Cycle {entry.cycle}
+                </span>
+                <span className={`text-xs font-semibold ${cfg.text}`}>
+                  {cfg.label}
+                </span>
+              </div>
+              <div className="flex items-center justify-between mt-0.5">
+                <span className="text-xs text-surface-400 dark:text-slate-500">
+                  {entry.timestamp ? getRelativeTime(entry.timestamp) : '—'}
+                </span>
+                <span className="text-xs font-bold text-surface-800 dark:text-slate-200">
+                  {entry.amount.toFixed(2)} XLM
+                </span>
+              </div>
+            </div>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/frontend/src/components/GroupDetailPage.tsx
+++ b/frontend/src/components/GroupDetailPage.tsx
@@ -5,6 +5,7 @@
 import React, { useState } from 'react'
 import { ContributionForm } from './ContributionForm'
 import { MemberList } from './MemberList'
+import { MemberProfileCard } from './MemberProfileCard'
 import { TransactionHistory } from './TransactionHistory'
 import InviteModal from './InviteModal'
 import { useGroupDetail, useGroupMembers } from '../hooks/useContractData'
@@ -167,10 +168,23 @@ export const GroupDetailPage: React.FC<GroupDetailPageProps> = ({
           )}
 
           {activeTab === 'members' && (
-            <>
-              {/* MemberList now fetches its own data via useGroupMembers hook */}
-              <MemberList groupId={groupId} />
-            </>
+            <div className="space-y-4">
+              {/* Profile cards grid */}
+              {members && members.length > 0 ? (
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                  {members.map((member) => (
+                    <MemberProfileCard
+                      key={member.address}
+                      member={member}
+                      groupId={groupId}
+                    />
+                  ))}
+                </div>
+              ) : (
+                /* Fallback to table view */
+                <MemberList groupId={groupId} />
+              )}
+            </div>
           )}
 
           {activeTab === 'history' && <TransactionHistory groupId={groupId} />}

--- a/frontend/src/components/MemberProfileCard.tsx
+++ b/frontend/src/components/MemberProfileCard.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+// Issue #408: Member profile cards with contribution history and reliability score
+import React, { useState } from 'react'
+import type { Member } from '@/types'
+import { useMemberStats } from '@/hooks/useMemberStats'
+import { MemberStats } from './MemberStats'
+import { ContributionTimeline } from './ContributionTimeline'
+import {
+  generateAvatarColor,
+  getAddressInitials,
+  shortenAddress,
+  formatDate,
+} from '@/utils/avatarUtils'
+
+interface MemberProfileCardProps {
+  member: Member
+  groupId: string
+  /** Show as a compact inline card (e.g. inside a list) */
+  compact?: boolean
+}
+
+export const MemberProfileCard: React.FC<MemberProfileCardProps> = ({
+  member,
+  groupId,
+  compact = false,
+}) => {
+  const { stats, loading } = useMemberStats(member.address, groupId)
+  const [expanded, setExpanded] = useState(false)
+
+  const avatarColor = generateAvatarColor(member.address)
+  const initials = getAddressInitials(member.address)
+  const shortAddr = shortenAddress(member.address)
+
+  const statusBadge = {
+    active: 'badge badge-active',
+    inactive: 'badge badge-paused',
+    completed: 'badge badge-completed',
+  }[member.status]
+
+  const statusDot = {
+    active: 'bg-emerald-500',
+    inactive: 'bg-amber-400',
+    completed: 'bg-primary-500',
+  }[member.status]
+
+  if (loading) {
+    return (
+      <div
+        className="relative overflow-hidden rounded-2xl bg-white dark:bg-slate-800 border border-surface-200/80 dark:border-slate-700 p-5"
+        aria-busy="true"
+        aria-label="Loading member profile"
+      >
+        <div className="absolute inset-0 -translate-x-full animate-shimmer bg-gradient-to-r from-transparent via-white/20 to-transparent z-10" />
+        <div className="flex items-center gap-4">
+          <div className="skeleton w-14 h-14 rounded-full flex-shrink-0" />
+          <div className="flex-1 space-y-2">
+            <div className="skeleton h-4 w-28 rounded" />
+            <div className="skeleton h-3.5 w-20 rounded" />
+            <div className="skeleton h-3 w-16 rounded" />
+          </div>
+          <div className="skeleton h-6 w-16 rounded-full" />
+        </div>
+        {!compact && (
+          <div className="mt-5 space-y-3">
+            <div className="skeleton h-2.5 w-full rounded-full" />
+            <div className="grid grid-cols-3 gap-2">
+              {[...Array(3)].map((_, i) => <div key={i} className="skeleton h-14 rounded-xl" />)}
+            </div>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <article
+      className={`
+        relative overflow-hidden rounded-2xl
+        bg-white dark:bg-slate-800
+        border border-surface-200/80 dark:border-slate-700
+        transition-all duration-300 ease-out
+        hover:shadow-card-hover hover:-translate-y-0.5
+        ${compact ? 'p-4' : 'p-5'}
+      `}
+    >
+      {/* Gradient accent top bar */}
+      <div
+        className="absolute top-0 left-0 right-0 h-1 rounded-t-2xl"
+        style={{ background: avatarColor }}
+      />
+
+      {/* Creator badge */}
+      {stats.isCreator && (
+        <div className="absolute top-3 right-3">
+          <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold bg-gradient-to-r from-amber-400 to-orange-500 text-white">
+            👑 Creator
+          </span>
+        </div>
+      )}
+
+      {/* Header row */}
+      <div className="flex items-center gap-4 pt-1">
+        {/* Avatar */}
+        <div className="relative flex-shrink-0">
+          <div
+            className="w-14 h-14 rounded-full flex items-center justify-center text-white font-bold text-lg select-none"
+            style={{ backgroundColor: avatarColor }}
+            aria-hidden="true"
+          >
+            {initials}
+          </div>
+          {/* Online dot */}
+          <span
+            className={`absolute bottom-0.5 right-0.5 w-3 h-3 rounded-full border-2 border-white dark:border-slate-800 ${statusDot}`}
+            aria-hidden="true"
+          />
+        </div>
+
+        {/* Identity */}
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-bold text-surface-900 dark:text-slate-100 font-mono truncate">
+            {shortAddr}
+          </p>
+          <p className="text-xs text-surface-400 dark:text-slate-500 mt-0.5">
+            Joined {formatDate(member.joinedDate)}
+          </p>
+          {/* Reliability inline */}
+          <p className={`text-xs font-semibold mt-0.5 ${
+            stats.reliabilityScore >= 90
+              ? 'text-emerald-600 dark:text-emerald-400'
+              : stats.reliabilityScore >= 70
+              ? 'text-amber-600 dark:text-amber-400'
+              : 'text-red-600 dark:text-red-400'
+          }`}>
+            {stats.reliabilityScore}% reliable
+          </p>
+        </div>
+
+        {/* Status badge */}
+        <span className={`${statusBadge} flex-shrink-0`}>
+          <span className={`inline-block w-1.5 h-1.5 rounded-full ${statusDot}`} />
+          {member.status.charAt(0).toUpperCase() + member.status.slice(1)}
+        </span>
+      </div>
+
+      {/* Compact mode: just show stats inline, no expand */}
+      {compact ? (
+        <div className="mt-4">
+          <MemberStats
+            reliabilityScore={stats.reliabilityScore}
+            totalContributed={stats.totalContributed}
+            contributions={stats.contributions}
+            cyclesCompleted={stats.cyclesCompleted}
+            rank={stats.rank}
+            achievements={stats.achievements}
+          />
+        </div>
+      ) : (
+        <>
+          {/* Stats always visible */}
+          <div className="mt-5">
+            <MemberStats
+              reliabilityScore={stats.reliabilityScore}
+              totalContributed={stats.totalContributed}
+              contributions={stats.contributions}
+              cyclesCompleted={stats.cyclesCompleted}
+              rank={stats.rank}
+              achievements={stats.achievements}
+            />
+          </div>
+
+          {/* Expandable timeline */}
+          <div className="mt-4 border-t border-surface-100 dark:border-slate-700 pt-4">
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="flex items-center justify-between w-full text-left group"
+              aria-expanded={expanded}
+              aria-controls={`timeline-${member.address}`}
+            >
+              <span className="text-xs font-semibold text-surface-500 dark:text-slate-400 uppercase tracking-wider">
+                Contribution History
+              </span>
+              <svg
+                className={`w-4 h-4 text-surface-400 dark:text-slate-500 transition-transform duration-200 ${expanded ? 'rotate-180' : ''}`}
+                fill="none" viewBox="0 0 24 24" stroke="currentColor"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+
+            {expanded && (
+              <div
+                id={`timeline-${member.address}`}
+                className="mt-3 animate-fade-in"
+              >
+                <ContributionTimeline contributions={stats.history} />
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </article>
+  )
+}

--- a/frontend/src/components/MemberStats.tsx
+++ b/frontend/src/components/MemberStats.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import React from 'react'
+import type { Achievement } from '@/hooks/useMemberStats'
+
+interface MemberStatsProps {
+  reliabilityScore: number
+  totalContributed: number
+  contributions: number
+  cyclesCompleted: number
+  rank: number
+  achievements: Achievement[]
+  isLoading?: boolean
+}
+
+const achievementIcons: Record<string, string> = {
+  first_contribution: '🌱',
+  perfect_streak: '⚡',
+  early_bird: '🐦',
+  top_contributor: '🏆',
+  veteran: '🎖️',
+}
+
+function scoreColor(score: number): string {
+  if (score >= 90) return 'text-emerald-600 dark:text-emerald-400'
+  if (score >= 70) return 'text-amber-600 dark:text-amber-400'
+  return 'text-red-600 dark:text-red-400'
+}
+
+function scoreBarColor(score: number): string {
+  if (score >= 90) return 'from-emerald-400 to-teal-500'
+  if (score >= 70) return 'from-amber-400 to-orange-500'
+  return 'from-red-400 to-rose-500'
+}
+
+export const MemberStats: React.FC<MemberStatsProps> = ({
+  reliabilityScore,
+  totalContributed,
+  contributions,
+  cyclesCompleted,
+  rank,
+  achievements,
+  isLoading = false,
+}) => {
+  if (isLoading) {
+    return (
+      <div className="space-y-4" aria-busy="true">
+        <div className="skeleton h-4 w-32 rounded" />
+        <div className="skeleton h-2.5 w-full rounded-full" />
+        <div className="grid grid-cols-3 gap-3">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="skeleton h-14 rounded-xl" />
+          ))}
+        </div>
+        <div className="flex gap-2">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="skeleton h-7 w-16 rounded-full" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  const earned = achievements.filter((a) => a.earned)
+
+  return (
+    <div className="space-y-4">
+      {/* Reliability score */}
+      <div>
+        <div className="flex items-center justify-between mb-1.5">
+          <span className="text-xs font-semibold text-surface-500 dark:text-slate-400 uppercase tracking-wider">
+            Reliability
+          </span>
+          <span className={`text-sm font-extrabold ${scoreColor(reliabilityScore)}`}>
+            {reliabilityScore}%
+          </span>
+        </div>
+        <div className="h-2 w-full rounded-full bg-surface-100 dark:bg-slate-700 overflow-hidden">
+          <div
+            className={`h-full rounded-full bg-gradient-to-r ${scoreBarColor(reliabilityScore)} transition-all duration-700`}
+            style={{ width: `${reliabilityScore}%` }}
+            role="progressbar"
+            aria-valuenow={reliabilityScore}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`Reliability score: ${reliabilityScore}%`}
+          />
+        </div>
+      </div>
+
+      {/* Stat pills */}
+      <div className="grid grid-cols-3 gap-2">
+        {[
+          { label: 'Contributed', value: `${totalContributed.toFixed(1)} XLM` },
+          { label: 'Cycles', value: cyclesCompleted },
+          { label: 'Rank', value: `#${rank}` },
+        ].map(({ label, value }) => (
+          <div
+            key={label}
+            className="bg-surface-50 dark:bg-slate-700/50 rounded-xl p-2.5 text-center border border-surface-100 dark:border-slate-700"
+          >
+            <p className="text-xs text-surface-400 dark:text-slate-500 font-medium">{label}</p>
+            <p className="text-sm font-bold text-surface-900 dark:text-slate-100 mt-0.5 truncate">
+              {value}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Achievements */}
+      {earned.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-surface-500 dark:text-slate-400 uppercase tracking-wider mb-2">
+            Achievements
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {earned.map((a) => (
+              <span
+                key={a.id}
+                title={a.description}
+                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold bg-primary-50 dark:bg-indigo-900/30 text-primary-700 dark:text-indigo-300 border border-primary-100 dark:border-indigo-800"
+              >
+                <span aria-hidden="true">{achievementIcons[a.id]}</span>
+                {a.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useMemberStats.ts
+++ b/frontend/src/hooks/useMemberStats.ts
@@ -1,0 +1,136 @@
+import { useMemo } from 'react'
+import { useGroupMembers, useTransactions } from './useContractData'
+
+export interface ContributionEntry {
+  cycle: number
+  amount: number
+  timestamp: string
+  status: 'confirmed' | 'pending' | 'failed'
+}
+
+export type AchievementId =
+  | 'first_contribution'
+  | 'perfect_streak'
+  | 'early_bird'
+  | 'top_contributor'
+  | 'veteran'
+
+export interface Achievement {
+  id: AchievementId
+  label: string
+  description: string
+  earned: boolean
+}
+
+export interface MemberStats {
+  reliabilityScore: number   // 0–100
+  totalContributed: number
+  contributions: number
+  cyclesCompleted: number
+  history: ContributionEntry[]
+  achievements: Achievement[]
+  rank: number               // position in group by contributions
+  isCreator: boolean
+}
+
+function computeReliability(contributions: number, cyclesCompleted: number): number {
+  if (cyclesCompleted === 0) return 100
+  return Math.min(100, Math.round((contributions / cyclesCompleted) * 100))
+}
+
+function buildAchievements(stats: {
+  contributions: number
+  cyclesCompleted: number
+  reliabilityScore: number
+  isCreator: boolean
+  rank: number
+  totalMembers: number
+}): Achievement[] {
+  return [
+    {
+      id: 'first_contribution',
+      label: 'First Step',
+      description: 'Made your first contribution',
+      earned: stats.contributions >= 1,
+    },
+    {
+      id: 'perfect_streak',
+      label: 'Perfect Streak',
+      description: '100% on-time contributions',
+      earned: stats.reliabilityScore === 100 && stats.contributions >= 3,
+    },
+    {
+      id: 'early_bird',
+      label: 'Early Bird',
+      description: 'Joined in the first cycle',
+      earned: stats.isCreator,
+    },
+    {
+      id: 'top_contributor',
+      label: 'Top Contributor',
+      description: 'Highest total in the group',
+      earned: stats.rank === 1 && stats.totalMembers > 1,
+    },
+    {
+      id: 'veteran',
+      label: 'Veteran',
+      description: 'Completed 5+ cycles',
+      earned: stats.cyclesCompleted >= 5,
+    },
+  ]
+}
+
+export function useMemberStats(
+  address: string,
+  groupId: string
+): { stats: MemberStats; loading: boolean } {
+  const { data: members = [], isLoading: membersLoading } = useGroupMembers(groupId)
+  const { data: txData, isLoading: txLoading } = useTransactions(groupId)
+
+  const stats = useMemo<MemberStats>(() => {
+    const member = members.find((m) => m.address === address)
+    const allTx = (txData as any)?.transactions ?? txData ?? []
+
+    const memberTx: ContributionEntry[] = (allTx as any[])
+      .filter((t) => t.member === address && t.type === 'contribution')
+      .map((t, i) => ({
+        cycle: i + 1,
+        amount: t.amount,
+        timestamp: t.timestamp ?? t.date ?? '',
+        status: t.status === 'confirmed' || t.status === 'completed' ? 'confirmed'
+          : t.status === 'pending' ? 'pending' : 'failed',
+      }))
+
+    const contributions = member?.contributions ?? memberTx.length
+    const cyclesCompleted = member?.cyclesCompleted ?? contributions
+    const totalContributed = member?.totalContributed ?? memberTx.reduce((s, t) => s + t.amount, 0)
+    const reliabilityScore = computeReliability(contributions, cyclesCompleted)
+
+    // Rank by totalContributed descending
+    const sorted = [...members].sort((a, b) => (b.totalContributed ?? 0) - (a.totalContributed ?? 0))
+    const rank = sorted.findIndex((m) => m.address === address) + 1 || 1
+    const isCreator = members[0]?.address === address
+
+    const achievements = buildAchievements({
+      contributions,
+      cyclesCompleted,
+      reliabilityScore,
+      isCreator,
+      rank,
+      totalMembers: members.length,
+    })
+
+    return {
+      reliabilityScore,
+      totalContributed,
+      contributions,
+      cyclesCompleted,
+      history: memberTx,
+      achievements,
+      rank,
+      isCreator,
+    }
+  }, [address, members, txData])
+
+  return { stats, loading: membersLoading || txLoading }
+}


### PR DESCRIPTION
feat(frontend): add member profile cards

Introduces detailed member profile cards with contribution history, reliability scoring, achievements, and a collapsible timeline — replacing the plain table in the group detail members tab.

New files

useMemberStats.ts
 — derives MemberStats from useGroupMembers + useTransactions: computes reliability score (contributions / cycles × 100), ranks members by total contributed, builds 5 achievement types (first_contribution, perfect_streak, early_bird, top_contributor, veteran), and maps transactions into a typed ContributionEntry[] history

MemberStats.tsx
 — displays the reliability score as a gradient progress bar (green ≥90%, amber ≥70%, red below), a 3-column stat grid (contributed, cycles, rank), and earned achievement badges with emoji icons and tooltips

ContributionTimeline.tsx
 — vertical timeline of the last 5 contributions with cycle number, relative timestamp, amount, and colour-coded status dots (confirmed / pending / failed)

MemberProfileCard.tsx
 — the main card: deterministic avatar with colour from address, status dot, shortened address, join date, inline reliability score, MemberStats, and a collapsible ContributionTimeline behind an expand toggle. Includes shimmer skeleton loading state, creator crown badge, gradient accent top bar, and hover lift effect. Supports compact prop for list contexts.

Updated

GroupDetailPage.tsx — members tab now renders a responsive grid-cols-1 md:grid-cols-2 xl:grid-cols-3 of MemberProfileCard components, falling back to the existing MemberList table when no member data is available
Accessibility

aria-busy on loading states, aria-expanded/aria-controls on the timeline toggle, role="progressbar" with aria-valuenow/min/max on the reliability bar, aria-label on timeline list
Closes #408