### PR TITLE
feat(backend): implement MJML email templates system

### DIFF
--- a/backend/src/emails/base.mjml
+++ b/backend/src/emails/base.mjml
@@ -1,0 +1,2 @@
+<!-- Base layout — not used directly, shared structure documented here -->
+<!-- All templates use mj-wrapper with the brand header/footer pattern below -->

--- a/backend/src/emails/contributionReminder.mjml
+++ b/backend/src/emails/contributionReminder.mjml
@@ -1,0 +1,77 @@
+<mjml>
+  <mj-head>
+    <mj-title>Contribution Reminder</mj-title>
+    <mj-preview>Your contribution for {{groupName}} is due {{dueDate}}.</mj-preview>
+    <mj-attributes>
+      <mj-all font-family="Inter, Arial, sans-serif" />
+      <mj-text font-size="15px" line-height="1.6" color="#1e293b" />
+      <mj-button background-color="#4f46e5" border-radius="8px" font-size="15px" font-weight="600" inner-padding="14px 28px" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#f1f5f9">
+
+    <!-- Header -->
+    <mj-section background-color="#f59e0b" padding="28px 24px 20px">
+      <mj-column>
+        <mj-text align="center" color="#ffffff" font-size="26px" font-weight="700">🪙 Ajo</mj-text>
+        <mj-text align="center" color="rgba(255,255,255,0.9)" font-size="13px" padding-top="4px">
+          Contribution Reminder
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Body -->
+    <mj-section background-color="#ffffff" padding="36px 32px 28px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="700" color="#0f172a" padding-bottom="8px">
+          ⏰ Your contribution is due soon
+        </mj-text>
+        <mj-text color="#475569">
+          Don't miss your contribution window for <strong>{{groupName}}</strong>. Late contributions incur a penalty and are only accepted during the grace period.
+        </mj-text>
+
+        <!-- Details box -->
+        <mj-section background-color="#fffbeb" border-radius="10px" padding="20px 24px" border="1px solid #fde68a">
+          <mj-column>
+            <mj-table>
+              <tr>
+                <td style="padding: 6px 0; color: #92400e; font-size: 13px; font-weight: 600; width: 140px;">Group</td>
+                <td style="padding: 6px 0; color: #1e293b; font-size: 14px; font-weight: 700;">{{groupName}}</td>
+              </tr>
+              <tr>
+                <td style="padding: 6px 0; color: #92400e; font-size: 13px; font-weight: 600;">Amount</td>
+                <td style="padding: 6px 0; color: #1e293b; font-size: 14px; font-weight: 700;">{{amount}}</td>
+              </tr>
+              <tr>
+                <td style="padding: 6px 0; color: #92400e; font-size: 13px; font-weight: 600;">Due Date</td>
+                <td style="padding: 6px 0; color: #1e293b; font-size: 14px; font-weight: 700;">{{dueDate}}</td>
+              </tr>
+              <tr>
+                <td style="padding: 6px 0; color: #92400e; font-size: 13px; font-weight: 600;">Cycle</td>
+                <td style="padding: 6px 0; color: #1e293b; font-size: 14px; font-weight: 700;">{{cycleNumber}}</td>
+              </tr>
+            </mj-table>
+          </mj-column>
+        </mj-section>
+
+        <mj-button href="{{groupUrl}}" align="left" padding-top="24px">
+          Make Contribution →
+        </mj-button>
+
+        <mj-text font-size="13px" color="#94a3b8" padding-top="16px">
+          If you've already contributed, you can safely ignore this reminder.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Footer -->
+    <mj-section padding="20px 32px">
+      <mj-column>
+        <mj-text align="center" font-size="12px" color="#94a3b8">
+          <a href="{{unsubscribeUrl}}" style="color: #94a3b8;">Unsubscribe from reminders</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+  </mj-body>
+</mjml>

--- a/backend/src/emails/emailVerification.mjml
+++ b/backend/src/emails/emailVerification.mjml
@@ -1,0 +1,62 @@
+<mjml>
+  <mj-head>
+    <mj-title>Verify Your Email</mj-title>
+    <mj-preview>Confirm your email address to activate your Ajo account.</mj-preview>
+    <mj-attributes>
+      <mj-all font-family="Inter, Arial, sans-serif" />
+      <mj-text font-size="15px" line-height="1.6" color="#1e293b" />
+      <mj-button background-color="#4f46e5" border-radius="8px" font-size="15px" font-weight="600" inner-padding="14px 28px" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#f1f5f9">
+
+    <!-- Header -->
+    <mj-section background-color="#4f46e5" padding="28px 24px 20px">
+      <mj-column>
+        <mj-text align="center" color="#ffffff" font-size="26px" font-weight="700">🪙 Ajo</mj-text>
+        <mj-text align="center" color="rgba(255,255,255,0.85)" font-size="13px" padding-top="4px">
+          Email Verification
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Body -->
+    <mj-section background-color="#ffffff" padding="40px 32px 32px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="700" color="#0f172a" padding-bottom="8px">
+          Confirm your email address
+        </mj-text>
+        <mj-text color="#475569">
+          Click the button below to verify your email and activate your Ajo account. This link expires in <strong>24 hours</strong>.
+        </mj-text>
+
+        <mj-button href="{{verifyLink}}" align="left" padding-top="24px">
+          Verify Email Address →
+        </mj-button>
+
+        <mj-divider border-color="#e2e8f0" padding="28px 0 20px" />
+
+        <mj-text font-size="13px" color="#64748b">
+          Or copy and paste this URL into your browser:
+        </mj-text>
+        <mj-text font-size="12px" color="#4f46e5" font-family="monospace" padding-top="4px">
+          {{verifyLink}}
+        </mj-text>
+
+        <mj-text font-size="13px" color="#94a3b8" padding-top="20px">
+          If you didn't create an Ajo account, you can safely ignore this email.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Footer -->
+    <mj-section padding="20px 32px">
+      <mj-column>
+        <mj-text align="center" font-size="12px" color="#94a3b8">
+          This is an automated message — please do not reply.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+  </mj-body>
+</mjml>

--- a/backend/src/emails/groupInvitation.mjml
+++ b/backend/src/emails/groupInvitation.mjml
@@ -1,0 +1,76 @@
+<mjml>
+  <mj-head>
+    <mj-title>You're invited to join {{groupName}}</mj-title>
+    <mj-preview>{{inviterName}} invited you to join {{groupName}} on Ajo.</mj-preview>
+    <mj-attributes>
+      <mj-all font-family="Inter, Arial, sans-serif" />
+      <mj-text font-size="15px" line-height="1.6" color="#1e293b" />
+      <mj-button background-color="#4f46e5" border-radius="8px" font-size="15px" font-weight="600" inner-padding="14px 28px" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#f1f5f9">
+
+    <!-- Header -->
+    <mj-section background-color="#4f46e5" padding="28px 24px 20px">
+      <mj-column>
+        <mj-text align="center" color="#ffffff" font-size="26px" font-weight="700">🪙 Ajo</mj-text>
+        <mj-text align="center" color="rgba(255,255,255,0.85)" font-size="13px" padding-top="4px">
+          Group Invitation
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Body -->
+    <mj-section background-color="#ffffff" padding="36px 32px 32px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="700" color="#0f172a" padding-bottom="8px">
+          You've been invited! 🎉
+        </mj-text>
+        <mj-text color="#475569">
+          <strong>{{inviterName}}</strong> has invited you to join their savings group on Ajo.
+        </mj-text>
+
+        <!-- Group card -->
+        <mj-section background-color="#f8fafc" border-radius="10px" padding="20px 24px" border="1px solid #e2e8f0">
+          <mj-column>
+            <mj-text font-size="18px" font-weight="700" color="#0f172a" padding-bottom="4px">
+              {{groupName}}
+            </mj-text>
+            <mj-table>
+              <tr>
+                <td style="padding: 5px 0; color: #64748b; font-size: 13px; width: 140px;">Contribution</td>
+                <td style="padding: 5px 0; color: #1e293b; font-size: 14px; font-weight: 600;">{{contributionAmount}} per cycle</td>
+              </tr>
+              <tr>
+                <td style="padding: 5px 0; color: #64748b; font-size: 13px;">Cycle Length</td>
+                <td style="padding: 5px 0; color: #1e293b; font-size: 14px; font-weight: 600;">{{cycleDuration}}</td>
+              </tr>
+              <tr>
+                <td style="padding: 5px 0; color: #64748b; font-size: 13px;">Members</td>
+                <td style="padding: 5px 0; color: #1e293b; font-size: 14px; font-weight: 600;">{{currentMembers}} / {{maxMembers}}</td>
+              </tr>
+            </mj-table>
+          </mj-column>
+        </mj-section>
+
+        <mj-button href="{{inviteLink}}" align="left" padding-top="24px">
+          Accept Invitation →
+        </mj-button>
+
+        <mj-text font-size="13px" color="#94a3b8" padding-top="12px">
+          This invitation expires in 7 days. If you didn't expect this, you can safely ignore it.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Footer -->
+    <mj-section padding="20px 32px">
+      <mj-column>
+        <mj-text align="center" font-size="12px" color="#94a3b8">
+          <a href="{{unsubscribeUrl}}" style="color: #94a3b8;">Unsubscribe</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+  </mj-body>
+</mjml>

--- a/backend/src/emails/payoutNotification.mjml
+++ b/backend/src/emails/payoutNotification.mjml
@@ -1,0 +1,80 @@
+<mjml>
+  <mj-head>
+    <mj-title>Payout Received</mj-title>
+    <mj-preview>🎉 You received {{amount}} from {{groupName}}!</mj-preview>
+    <mj-attributes>
+      <mj-all font-family="Inter, Arial, sans-serif" />
+      <mj-text font-size="15px" line-height="1.6" color="#1e293b" />
+      <mj-button background-color="#10b981" border-radius="8px" font-size="15px" font-weight="600" inner-padding="14px 28px" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#f1f5f9">
+
+    <!-- Header -->
+    <mj-section background-color="#10b981" padding="28px 24px 20px">
+      <mj-column>
+        <mj-text align="center" color="#ffffff" font-size="26px" font-weight="700">🪙 Ajo</mj-text>
+        <mj-text align="center" color="rgba(255,255,255,0.9)" font-size="13px" padding-top="4px">
+          Payout Received
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Hero amount -->
+    <mj-section background-color="#ffffff" padding="36px 32px 0">
+      <mj-column>
+        <mj-text align="center" font-size="13px" font-weight="600" color="#10b981" letter-spacing="1px">
+          PAYOUT CONFIRMED
+        </mj-text>
+        <mj-text align="center" font-size="42px" font-weight="800" color="#0f172a" padding-top="4px" padding-bottom="4px">
+          {{amount}}
+        </mj-text>
+        <mj-text align="center" font-size="14px" color="#64748b" padding-top="0">
+          from <strong>{{groupName}}</strong> · Cycle {{cycleNumber}}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Details -->
+    <mj-section background-color="#ffffff" padding="24px 32px 32px">
+      <mj-column>
+        <mj-section background-color="#ecfdf5" border-radius="10px" padding="20px 24px" border="1px solid #a7f3d0">
+          <mj-column>
+            <mj-table>
+              <tr>
+                <td style="padding: 6px 0; color: #065f46; font-size: 13px; font-weight: 600; width: 140px;">Group</td>
+                <td style="padding: 6px 0; color: #1e293b; font-size: 14px; font-weight: 700;">{{groupName}}</td>
+              </tr>
+              <tr>
+                <td style="padding: 6px 0; color: #065f46; font-size: 13px; font-weight: 600;">Amount</td>
+                <td style="padding: 6px 0; color: #1e293b; font-size: 14px; font-weight: 700;">{{amount}}</td>
+              </tr>
+              <tr>
+                <td style="padding: 6px 0; color: #065f46; font-size: 13px; font-weight: 600;">Date</td>
+                <td style="padding: 6px 0; color: #1e293b; font-size: 14px;">{{date}}</td>
+              </tr>
+              <tr>
+                <td style="padding: 6px 0; color: #065f46; font-size: 13px; font-weight: 600;">Tx Hash</td>
+                <td style="padding: 6px 0; color: #475569; font-size: 12px; font-family: monospace;">{{txHash}}</td>
+              </tr>
+            </mj-table>
+          </mj-column>
+        </mj-section>
+
+        <mj-button href="{{txUrl}}" align="left" padding-top="24px">
+          View Transaction →
+        </mj-button>
+      </mj-column>
+    </mj-section>
+
+    <!-- Footer -->
+    <mj-section padding="20px 32px">
+      <mj-column>
+        <mj-text align="center" font-size="12px" color="#94a3b8">
+          <a href="{{unsubscribeUrl}}" style="color: #94a3b8;">Unsubscribe</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+  </mj-body>
+</mjml>

--- a/backend/src/emails/templateEngine.ts
+++ b/backend/src/emails/templateEngine.ts
@@ -1,0 +1,223 @@
+/**
+ * Email template engine
+ * Issue #378: MJML-based email template system
+ *
+ * Compiles MJML templates to responsive HTML and injects
+ * typed variables using a simple {{variable}} syntax.
+ */
+import mjml2html from 'mjml'
+import fs from 'fs'
+import path from 'path'
+import { createModuleLogger } from '../utils/logger'
+
+const logger = createModuleLogger('EmailTemplateEngine')
+
+const TEMPLATES_DIR = path.join(__dirname)
+
+// ── Template variable types ────────────────────────────────────────────────
+
+export interface WelcomeVars {
+  name: string
+  dashboardUrl: string
+  unsubscribeUrl: string
+}
+
+export interface ContributionReminderVars {
+  groupName: string
+  amount: string
+  dueDate: string
+  cycleNumber: string | number
+  groupUrl: string
+  unsubscribeUrl: string
+}
+
+export interface PayoutNotificationVars {
+  groupName: string
+  amount: string
+  cycleNumber: string | number
+  date: string
+  txHash: string
+  txUrl: string
+  unsubscribeUrl: string
+}
+
+export interface GroupInvitationVars {
+  groupName: string
+  inviterName: string
+  contributionAmount: string
+  cycleDuration: string
+  currentMembers: string | number
+  maxMembers: string | number
+  inviteLink: string
+  unsubscribeUrl: string
+}
+
+export interface TransactionReceiptVars {
+  groupName: string
+  amount: string
+  cycleNumber: string | number
+  date: string
+  txHash: string
+  txUrl: string
+  unsubscribeUrl: string
+}
+
+export interface WeeklySummaryVars {
+  weekOf: string
+  activeGroups: string | number
+  totalSaved: string
+  contributionCount: string | number
+  /** Pre-rendered HTML rows for each group */
+  groupRows: string
+  dashboardUrl: string
+  unsubscribeUrl: string
+}
+
+export interface EmailVerificationVars {
+  verifyLink: string
+}
+
+export type TemplateVars =
+  | WelcomeVars
+  | ContributionReminderVars
+  | PayoutNotificationVars
+  | GroupInvitationVars
+  | TransactionReceiptVars
+  | WeeklySummaryVars
+  | EmailVerificationVars
+
+// ── Template names ─────────────────────────────────────────────────────────
+
+export type TemplateName =
+  | 'welcome'
+  | 'contributionReminder'
+  | 'payoutNotification'
+  | 'groupInvitation'
+  | 'transactionReceipt'
+  | 'weeklySummary'
+  | 'emailVerification'
+
+const TEMPLATE_FILES: Record<TemplateName, string> = {
+  welcome: 'welcome.mjml',
+  contributionReminder: 'contributionReminder.mjml',
+  payoutNotification: 'payoutNotification.mjml',
+  groupInvitation: 'groupInvitation.mjml',
+  transactionReceipt: 'transactionReceipt.mjml',
+  weeklySummary: 'weeklySummary.mjml',
+  emailVerification: 'emailVerification.mjml',
+}
+
+// In-memory cache of compiled HTML (keyed by template name)
+const compiledCache = new Map<TemplateName, string>()
+
+// ── Core functions ─────────────────────────────────────────────────────────
+
+/**
+ * Read and compile an MJML template to HTML.
+ * Results are cached in memory after the first compile.
+ */
+function compileTemplate(name: TemplateName): string {
+  if (compiledCache.has(name)) {
+    return compiledCache.get(name)!
+  }
+
+  const filePath = path.join(TEMPLATES_DIR, TEMPLATE_FILES[name])
+
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Email template not found: ${filePath}`)
+  }
+
+  const mjmlSource = fs.readFileSync(filePath, 'utf-8')
+
+  const { html, errors } = mjml2html(mjmlSource, {
+    validationLevel: 'soft',
+    filePath,
+  })
+
+  if (errors.length > 0) {
+    logger.warn(`MJML warnings in template "${name}"`, { errors })
+  }
+
+  compiledCache.set(name, html)
+  return html
+}
+
+/**
+ * Inject variables into a compiled HTML template.
+ * Replaces all {{variableName}} placeholders with their values.
+ * Unknown placeholders are left as-is.
+ */
+function injectVars(html: string, vars: Record<string, string>): string {
+  return html.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    return key in vars ? vars[key] : match
+  })
+}
+
+/**
+ * Render a named template with the provided variables.
+ * Returns the final HTML string ready to send.
+ */
+export function renderTemplate(name: TemplateName, vars: TemplateVars): string {
+  const html = compileTemplate(name)
+  return injectVars(html, vars as Record<string, string>)
+}
+
+/**
+ * Generate a plain-text fallback by stripping HTML tags.
+ */
+export function htmlToText(html: string): string {
+  return html
+    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+}
+
+/**
+ * Clear the compiled template cache (useful in tests or after template edits).
+ */
+export function clearTemplateCache(): void {
+  compiledCache.clear()
+}
+
+// ── Convenience helpers ────────────────────────────────────────────────────
+
+/** Build the weekly summary group rows HTML snippet */
+export function buildGroupRows(
+  groups: Array<{ name: string; contributions: number; balance: string; status: string }>
+): string {
+  if (groups.length === 0) {
+    return '<p style="color:#94a3b8;font-size:14px;">No group activity this week.</p>'
+  }
+
+  return groups
+    .map(
+      (g) => `
+    <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:10px;border-radius:8px;border:1px solid #e2e8f0;overflow:hidden;">
+      <tr>
+        <td style="padding:12px 16px;background:#f8fafc;">
+          <strong style="color:#0f172a;font-size:14px;">${escapeHtml(g.name)}</strong>
+          <span style="float:right;font-size:12px;color:${g.status === 'active' ? '#10b981' : '#f59e0b'};font-weight:600;text-transform:uppercase;">${escapeHtml(g.status)}</span>
+        </td>
+      </tr>
+      <tr>
+        <td style="padding:10px 16px;background:#ffffff;">
+          <span style="color:#64748b;font-size:13px;">Contributions: </span>
+          <strong style="color:#1e293b;font-size:13px;">${g.contributions}</strong>
+          &nbsp;&nbsp;
+          <span style="color:#64748b;font-size:13px;">Balance: </span>
+          <strong style="color:#1e293b;font-size:13px;">${escapeHtml(g.balance)}</strong>
+        </td>
+      </tr>
+    </table>`
+    )
+    .join('')
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/backend/src/emails/transactionReceipt.mjml
+++ b/backend/src/emails/transactionReceipt.mjml
@@ -1,0 +1,77 @@
+<mjml>
+  <mj-head>
+    <mj-title>Transaction Receipt</mj-title>
+    <mj-preview>Your contribution of {{amount}} to {{groupName}} has been confirmed.</mj-preview>
+    <mj-attributes>
+      <mj-all font-family="Inter, Arial, sans-serif" />
+      <mj-text font-size="15px" line-height="1.6" color="#1e293b" />
+      <mj-button background-color="#4f46e5" border-radius="8px" font-size="15px" font-weight="600" inner-padding="14px 28px" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#f1f5f9">
+
+    <!-- Header -->
+    <mj-section background-color="#4f46e5" padding="28px 24px 20px">
+      <mj-column>
+        <mj-text align="center" color="#ffffff" font-size="26px" font-weight="700">🪙 Ajo</mj-text>
+        <mj-text align="center" color="rgba(255,255,255,0.85)" font-size="13px" padding-top="4px">
+          Transaction Receipt
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Body -->
+    <mj-section background-color="#ffffff" padding="36px 32px 32px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="700" color="#0f172a" padding-bottom="8px">
+          ✅ Contribution confirmed
+        </mj-text>
+        <mj-text color="#475569">
+          Your contribution to <strong>{{groupName}}</strong> has been recorded on the Stellar blockchain.
+        </mj-text>
+
+        <!-- Receipt box -->
+        <mj-section background-color="#f8fafc" border-radius="10px" padding="20px 24px" border="1px solid #e2e8f0">
+          <mj-column>
+            <mj-table>
+              <tr>
+                <td style="padding: 7px 0; color: #64748b; font-size: 13px; font-weight: 600; width: 140px; border-bottom: 1px solid #f1f5f9;">Group</td>
+                <td style="padding: 7px 0; color: #1e293b; font-size: 14px; font-weight: 700; border-bottom: 1px solid #f1f5f9;">{{groupName}}</td>
+              </tr>
+              <tr>
+                <td style="padding: 7px 0; color: #64748b; font-size: 13px; font-weight: 600; border-bottom: 1px solid #f1f5f9;">Amount</td>
+                <td style="padding: 7px 0; color: #1e293b; font-size: 14px; font-weight: 700; border-bottom: 1px solid #f1f5f9;">{{amount}}</td>
+              </tr>
+              <tr>
+                <td style="padding: 7px 0; color: #64748b; font-size: 13px; font-weight: 600; border-bottom: 1px solid #f1f5f9;">Cycle</td>
+                <td style="padding: 7px 0; color: #1e293b; font-size: 14px; border-bottom: 1px solid #f1f5f9;">{{cycleNumber}}</td>
+              </tr>
+              <tr>
+                <td style="padding: 7px 0; color: #64748b; font-size: 13px; font-weight: 600; border-bottom: 1px solid #f1f5f9;">Date</td>
+                <td style="padding: 7px 0; color: #1e293b; font-size: 14px; border-bottom: 1px solid #f1f5f9;">{{date}}</td>
+              </tr>
+              <tr>
+                <td style="padding: 7px 0; color: #64748b; font-size: 13px; font-weight: 600;">Tx Hash</td>
+                <td style="padding: 7px 0; color: #475569; font-size: 11px; font-family: monospace; word-break: break-all;">{{txHash}}</td>
+              </tr>
+            </mj-table>
+          </mj-column>
+        </mj-section>
+
+        <mj-button href="{{txUrl}}" align="left" padding-top="24px">
+          View on Stellar →
+        </mj-button>
+      </mj-column>
+    </mj-section>
+
+    <!-- Footer -->
+    <mj-section padding="20px 32px">
+      <mj-column>
+        <mj-text align="center" font-size="12px" color="#94a3b8">
+          <a href="{{unsubscribeUrl}}" style="color: #94a3b8;">Unsubscribe</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+  </mj-body>
+</mjml>

--- a/backend/src/emails/weeklySummary.mjml
+++ b/backend/src/emails/weeklySummary.mjml
@@ -1,0 +1,78 @@
+<mjml>
+  <mj-head>
+    <mj-title>Your Weekly Ajo Summary</mj-title>
+    <mj-preview>Here's your savings activity for the week of {{weekOf}}.</mj-preview>
+    <mj-attributes>
+      <mj-all font-family="Inter, Arial, sans-serif" />
+      <mj-text font-size="15px" line-height="1.6" color="#1e293b" />
+      <mj-button background-color="#4f46e5" border-radius="8px" font-size="15px" font-weight="600" inner-padding="14px 28px" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#f1f5f9">
+
+    <!-- Header -->
+    <mj-section background-color="#4f46e5" padding="28px 24px 20px">
+      <mj-column>
+        <mj-text align="center" color="#ffffff" font-size="26px" font-weight="700">🪙 Ajo</mj-text>
+        <mj-text align="center" color="rgba(255,255,255,0.85)" font-size="13px" padding-top="4px">
+          Weekly Summary · {{weekOf}}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Stats row -->
+    <mj-section background-color="#ffffff" padding="32px 24px 0">
+      <mj-column background-color="#eef2ff" border-radius="10px" padding="20px 16px">
+        <mj-text align="center" font-size="11px" font-weight="700" color="#4f46e5" letter-spacing="1px">
+          ACTIVE GROUPS
+        </mj-text>
+        <mj-text align="center" font-size="32px" font-weight="800" color="#0f172a" padding-top="4px" padding-bottom="0">
+          {{activeGroups}}
+        </mj-text>
+      </mj-column>
+      <mj-column background-color="#ecfdf5" border-radius="10px" padding="20px 16px">
+        <mj-text align="center" font-size="11px" font-weight="700" color="#10b981" letter-spacing="1px">
+          TOTAL SAVED
+        </mj-text>
+        <mj-text align="center" font-size="32px" font-weight="800" color="#0f172a" padding-top="4px" padding-bottom="0">
+          {{totalSaved}}
+        </mj-text>
+      </mj-column>
+      <mj-column background-color="#faf5ff" border-radius="10px" padding="20px 16px">
+        <mj-text align="center" font-size="11px" font-weight="700" color="#7c3aed" letter-spacing="1px">
+          CONTRIBUTIONS
+        </mj-text>
+        <mj-text align="center" font-size="32px" font-weight="800" color="#0f172a" padding-top="4px" padding-bottom="0">
+          {{contributionCount}}
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Group breakdown -->
+    <mj-section background-color="#ffffff" padding="24px 32px 32px">
+      <mj-column>
+        <mj-text font-size="16px" font-weight="700" color="#0f172a" padding-bottom="12px">
+          Group Activity
+        </mj-text>
+
+        <!-- Repeated per group — template engine injects {{groupRows}} here -->
+        {{groupRows}}
+
+        <mj-button href="{{dashboardUrl}}" align="left" padding-top="24px">
+          View Full Dashboard →
+        </mj-button>
+      </mj-column>
+    </mj-section>
+
+    <!-- Footer -->
+    <mj-section padding="20px 32px">
+      <mj-column>
+        <mj-text align="center" font-size="12px" color="#94a3b8">
+          Weekly summaries are sent every Monday.<br />
+          <a href="{{unsubscribeUrl}}" style="color: #94a3b8;">Unsubscribe</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+  </mj-body>
+</mjml>

--- a/backend/src/emails/welcome.mjml
+++ b/backend/src/emails/welcome.mjml
@@ -1,0 +1,80 @@
+<mjml>
+  <mj-head>
+    <mj-title>Welcome to Ajo</mj-title>
+    <mj-preview>Start saving with your community on the Stellar blockchain.</mj-preview>
+    <mj-attributes>
+      <mj-all font-family="Inter, Arial, sans-serif" />
+      <mj-text font-size="15px" line-height="1.6" color="#1e293b" />
+      <mj-button background-color="#4f46e5" border-radius="8px" font-size="15px" font-weight="600" inner-padding="14px 28px" />
+    </mj-attributes>
+    <mj-style>
+      .brand-header { background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%); }
+      .stat-box { border-radius: 8px; }
+    </mj-style>
+  </mj-head>
+  <mj-body background-color="#f1f5f9">
+
+    <!-- Header -->
+    <mj-section css-class="brand-header" background-color="#4f46e5" padding="32px 24px 24px">
+      <mj-column>
+        <mj-text align="center" color="#ffffff" font-size="26px" font-weight="700" letter-spacing="-0.5px">
+          🪙 Ajo
+        </mj-text>
+        <mj-text align="center" color="rgba(255,255,255,0.8)" font-size="13px" padding-top="4px">
+          Decentralized Savings Groups
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <!-- Body -->
+    <mj-section background-color="#ffffff" padding="40px 32px 32px" border-radius="0 0 12px 12px">
+      <mj-column>
+        <mj-text font-size="22px" font-weight="700" color="#0f172a" padding-bottom="8px">
+          Welcome, {{name}}! 👋
+        </mj-text>
+        <mj-text color="#475569">
+          You're now part of Ajo — a decentralized platform for rotating savings groups (ROSCAs) powered by the Stellar blockchain.
+        </mj-text>
+        <mj-text color="#475569" padding-top="0">
+          Here's what you can do to get started:
+        </mj-text>
+
+        <!-- Steps -->
+        <mj-table padding="16px 0">
+          <tr>
+            <td style="padding: 10px 12px; background: #f8fafc; border-radius: 8px; border-left: 3px solid #4f46e5;">
+              <strong style="color: #4f46e5;">1.</strong> <span style="color: #334155;">Create or join a savings group</span>
+            </td>
+          </tr>
+          <tr><td style="height: 8px;"></td></tr>
+          <tr>
+            <td style="padding: 10px 12px; background: #f8fafc; border-radius: 8px; border-left: 3px solid #7c3aed;">
+              <strong style="color: #7c3aed;">2.</strong> <span style="color: #334155;">Connect your Freighter wallet</span>
+            </td>
+          </tr>
+          <tr><td style="height: 8px;"></td></tr>
+          <tr>
+            <td style="padding: 10px 12px; background: #f8fafc; border-radius: 8px; border-left: 3px solid #10b981;">
+              <strong style="color: #10b981;">3.</strong> <span style="color: #334155;">Make your first contribution</span>
+            </td>
+          </tr>
+        </mj-table>
+
+        <mj-button href="{{dashboardUrl}}" align="left" padding-top="24px">
+          Go to Dashboard →
+        </mj-button>
+      </mj-column>
+    </mj-section>
+
+    <!-- Footer -->
+    <mj-section padding="24px 32px">
+      <mj-column>
+        <mj-text align="center" font-size="12px" color="#94a3b8">
+          You received this because you signed up for Ajo.<br />
+          <a href="{{unsubscribeUrl}}" style="color: #94a3b8;">Unsubscribe</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+  </mj-body>
+</mjml>

--- a/backend/src/queues/emailQueue.ts
+++ b/backend/src/queues/emailQueue.ts
@@ -91,3 +91,85 @@ export async function getEmailQueueStats() {
     delayed,
   }
 }
+
+// ── Typed queueEmail helper (Issue #378) ──────────────────────────────────
+// Provides a clean API for controllers to enqueue specific email types
+// without importing the full EmailService.
+
+export const queueEmail = {
+  async custom(opts: { to: string; subject: string; html: string }): Promise<string> {
+    return addEmailJob({ to: opts.to, subject: opts.subject, body: opts.html })
+  },
+
+  async welcome(to: string, name: string): Promise<string> {
+    return addEmailJob({
+      to,
+      subject: 'Welcome to Ajo!',
+      body: '',
+      template: 'welcome',
+      // The actual render happens in the job worker via emailService
+    }, { priority: 5 })
+  },
+
+  async contributionReminder(
+    to: string,
+    groupName: string,
+    amount: string,
+    dueDate: string,
+    cycleNumber: number,
+    groupId: string
+  ): Promise<string> {
+    return addEmailJob({
+      to,
+      subject: `Contribution Reminder: ${groupName}`,
+      body: JSON.stringify({ groupName, amount, dueDate, cycleNumber, groupId }),
+      template: 'contributionReminder',
+    })
+  },
+
+  async payoutNotification(
+    to: string,
+    groupName: string,
+    amount: string,
+    txHash: string,
+    cycleNumber: number,
+    date: string
+  ): Promise<string> {
+    return addEmailJob({
+      to,
+      subject: `Payout Received: ${groupName}`,
+      body: JSON.stringify({ groupName, amount, txHash, cycleNumber, date }),
+      template: 'payoutNotification',
+    }, { priority: 10 })
+  },
+
+  async transactionReceipt(
+    to: string,
+    data: { groupName: string; amount: string; txHash: string; date: string; cycleNumber: number }
+  ): Promise<string> {
+    return addEmailJob({
+      to,
+      subject: 'Transaction Receipt',
+      body: JSON.stringify(data),
+      template: 'transactionReceipt',
+    }, { priority: 8 })
+  },
+
+  async weeklySummary(to: string, data: object): Promise<string> {
+    return addEmailJob({
+      to,
+      subject: 'Your Weekly Ajo Summary',
+      body: JSON.stringify(data),
+      template: 'weeklySummary',
+    })
+  },
+
+  async verification(to: string, token: string): Promise<string> {
+    return addEmailJob({
+      to,
+      subject: 'Verify Your Email',
+      body: JSON.stringify({ token }),
+      template: 'emailVerification',
+    }, { priority: 10 })
+  },
+}

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -1,9 +1,20 @@
+/**
+ * Email service
+ * Issue #378: MJML-based email template system
+ *
+ * Sends transactional emails via SendGrid using compiled MJML templates.
+ * All template rendering is delegated to the templateEngine module.
+ */
 import sgMail from '@sendgrid/mail'
 import { createModuleLogger } from '../utils/logger'
+import {
+  renderTemplate,
+  htmlToText,
+  buildGroupRows,
+} from '../emails/templateEngine'
 
 const logger = createModuleLogger('EmailService')
 
-// Initialize SendGrid
 if (process.env.SENDGRID_API_KEY) {
   sgMail.setApiKey(process.env.SENDGRID_API_KEY)
 }
@@ -15,18 +26,29 @@ export interface EmailOptions {
   text?: string
 }
 
+// ── Service class ──────────────────────────────────────────────────────────
+
 export class EmailService {
-  private fromEmail: string
-  private isEnabled: boolean
+  private readonly fromEmail: string
+  private readonly isEnabled: boolean
+  private readonly frontendUrl: string
+  private readonly unsubscribeBase: string
 
   constructor() {
     this.fromEmail = process.env.EMAIL_FROM || 'noreply@ajo.app'
     this.isEnabled = !!process.env.SENDGRID_API_KEY
+    this.frontendUrl = process.env.FRONTEND_URL || 'https://ajo.app'
+    this.unsubscribeBase = `${this.frontendUrl}/unsubscribe`
   }
+
+  // ── Low-level send ───────────────────────────────────────────────────────
 
   async sendEmail(options: EmailOptions): Promise<boolean> {
     if (!this.isEnabled) {
-      // Service disabled - no API key configured
+      logger.debug('Email service disabled — SENDGRID_API_KEY not set', {
+        to: options.to,
+        subject: options.subject,
+      })
       return false
     }
 
@@ -36,37 +58,47 @@ export class EmailService {
         from: this.fromEmail,
         subject: options.subject,
         html: options.html,
-        text: options.text || options.html.replace(/<[^>]*>/g, ''),
+        text: options.text ?? htmlToText(options.html),
       })
+      logger.info('Email sent', { to: options.to, subject: options.subject })
       return true
     } catch (error) {
-      logger.error('Email send failed', {
-        error,
-        to: options.to,
-        subject: options.subject,
-      })
+      logger.error('Email send failed', { error, to: options.to, subject: options.subject })
       return false
     }
   }
 
+  // ── Typed send methods ───────────────────────────────────────────────────
+
   async sendWelcomeEmail(to: string, name: string): Promise<boolean> {
-    return this.sendEmail({
-      to,
-      subject: 'Welcome to Ajo!',
-      html: this.getWelcomeTemplate(name),
+    const html = renderTemplate('welcome', {
+      name,
+      dashboardUrl: `${this.frontendUrl}/dashboard`,
+      unsubscribeUrl: this.unsubscribeBase,
     })
+    return this.sendEmail({ to, subject: 'Welcome to Ajo!', html })
   }
 
   async sendContributionReminder(
     to: string,
     groupName: string,
     amount: string,
-    dueDate: string
+    dueDate: string,
+    cycleNumber: number,
+    groupId: string
   ): Promise<boolean> {
+    const html = renderTemplate('contributionReminder', {
+      groupName,
+      amount,
+      dueDate,
+      cycleNumber,
+      groupUrl: `${this.frontendUrl}/groups/${groupId}`,
+      unsubscribeUrl: this.unsubscribeBase,
+    })
     return this.sendEmail({
       to,
       subject: `Contribution Reminder: ${groupName}`,
-      html: this.getContributionReminderTemplate(groupName, amount, dueDate),
+      html,
     })
   }
 
@@ -74,12 +106,23 @@ export class EmailService {
     to: string,
     groupName: string,
     amount: string,
-    txHash: string
+    txHash: string,
+    cycleNumber: number,
+    date: string
   ): Promise<boolean> {
+    const html = renderTemplate('payoutNotification', {
+      groupName,
+      amount,
+      cycleNumber,
+      date,
+      txHash,
+      txUrl: `${this.frontendUrl}/transactions/${txHash}`,
+      unsubscribeUrl: this.unsubscribeBase,
+    })
     return this.sendEmail({
       to,
       subject: `Payout Received: ${groupName}`,
-      html: this.getPayoutTemplate(groupName, amount, txHash),
+      html,
     })
   }
 
@@ -87,175 +130,79 @@ export class EmailService {
     to: string,
     groupName: string,
     inviterName: string,
-    inviteLink: string
+    inviteLink: string,
+    groupDetails: {
+      contributionAmount: string
+      cycleDuration: string
+      currentMembers: number
+      maxMembers: number
+    }
   ): Promise<boolean> {
+    const html = renderTemplate('groupInvitation', {
+      groupName,
+      inviterName,
+      inviteLink,
+      contributionAmount: groupDetails.contributionAmount,
+      cycleDuration: groupDetails.cycleDuration,
+      currentMembers: groupDetails.currentMembers,
+      maxMembers: groupDetails.maxMembers,
+      unsubscribeUrl: this.unsubscribeBase,
+    })
     return this.sendEmail({
       to,
       subject: `You're invited to join ${groupName}`,
-      html: this.getInvitationTemplate(groupName, inviterName, inviteLink),
-    })
-  }
-
-  async sendWeeklySummary(
-    to: string,
-    data: { groupName: string; contributions: number; balance: string }
-  ): Promise<boolean> {
-    return this.sendEmail({
-      to,
-      subject: 'Your Weekly Ajo Summary',
-      html: this.getWeeklySummaryTemplate(data),
+      html,
     })
   }
 
   async sendTransactionReceipt(
     to: string,
-    data: { groupName: string; amount: string; txHash: string; date: string }
+    data: {
+      groupName: string
+      amount: string
+      txHash: string
+      date: string
+      cycleNumber: number
+    }
   ): Promise<boolean> {
-    return this.sendEmail({
-      to,
-      subject: 'Transaction Receipt',
-      html: this.getReceiptTemplate(data),
+    const html = renderTemplate('transactionReceipt', {
+      groupName: data.groupName,
+      amount: data.amount,
+      cycleNumber: data.cycleNumber,
+      date: data.date,
+      txHash: data.txHash,
+      txUrl: `${this.frontendUrl}/transactions/${data.txHash}`,
+      unsubscribeUrl: this.unsubscribeBase,
     })
+    return this.sendEmail({ to, subject: 'Transaction Receipt', html })
+  }
+
+  async sendWeeklySummary(
+    to: string,
+    data: {
+      weekOf: string
+      activeGroups: number
+      totalSaved: string
+      contributionCount: number
+      groups: Array<{ name: string; contributions: number; balance: string; status: string }>
+    }
+  ): Promise<boolean> {
+    const html = renderTemplate('weeklySummary', {
+      weekOf: data.weekOf,
+      activeGroups: data.activeGroups,
+      totalSaved: data.totalSaved,
+      contributionCount: data.contributionCount,
+      groupRows: buildGroupRows(data.groups),
+      dashboardUrl: `${this.frontendUrl}/dashboard`,
+      unsubscribeUrl: this.unsubscribeBase,
+    })
+    return this.sendEmail({ to, subject: 'Your Weekly Ajo Summary', html })
   }
 
   async sendVerificationEmail(to: string, token: string): Promise<boolean> {
-    const verifyLink = `${process.env.FRONTEND_URL}/verify-email?token=${token}`
-    return this.sendEmail({
-      to,
-      subject: 'Verify Your Email',
-      html: this.getVerificationTemplate(verifyLink),
-    })
-  }
-
-  // Email Templates
-  private getWelcomeTemplate(name: string): string {
-    return `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h1 style="color: #4F46E5;">Welcome to Ajo!</h1>
-        <p>Hi ${name},</p>
-        <p>Thank you for joining Ajo, the decentralized savings platform.</p>
-        <p>Get started by creating or joining a savings group.</p>
-        <a href="${process.env.FRONTEND_URL}/dashboard" style="display: inline-block; padding: 12px 24px; background: #4F46E5; color: white; text-decoration: none; border-radius: 6px; margin: 20px 0;">Go to Dashboard</a>
-        <p style="color: #666; font-size: 12px; margin-top: 40px;">
-          <a href="${process.env.FRONTEND_URL}/unsubscribe">Unsubscribe</a>
-        </p>
-      </div>
-    `
-  }
-
-  private getContributionReminderTemplate(
-    groupName: string,
-    amount: string,
-    dueDate: string
-  ): string {
-    return `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #4F46E5;">Contribution Reminder</h2>
-        <p>Your contribution for <strong>${groupName}</strong> is due soon.</p>
-        <div style="background: #F3F4F6; padding: 20px; border-radius: 8px; margin: 20px 0;">
-          <p><strong>Amount:</strong> ${amount}</p>
-          <p><strong>Due Date:</strong> ${dueDate}</p>
-        </div>
-        <a href="${process.env.FRONTEND_URL}/groups" style="display: inline-block; padding: 12px 24px; background: #4F46E5; color: white; text-decoration: none; border-radius: 6px;">Make Contribution</a>
-        <p style="color: #666; font-size: 12px; margin-top: 40px;">
-          <a href="${process.env.FRONTEND_URL}/unsubscribe">Unsubscribe</a>
-        </p>
-      </div>
-    `
-  }
-
-  private getPayoutTemplate(groupName: string, amount: string, txHash: string): string {
-    return `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #10B981;">Payout Received!</h2>
-        <p>You've received a payout from <strong>${groupName}</strong>.</p>
-        <div style="background: #F3F4F6; padding: 20px; border-radius: 8px; margin: 20px 0;">
-          <p><strong>Amount:</strong> ${amount}</p>
-          <p><strong>Transaction:</strong> <code style="font-size: 11px;">${txHash}</code></p>
-        </div>
-        <a href="${process.env.FRONTEND_URL}/transactions/${txHash}" style="display: inline-block; padding: 12px 24px; background: #4F46E5; color: white; text-decoration: none; border-radius: 6px;">View Transaction</a>
-        <p style="color: #666; font-size: 12px; margin-top: 40px;">
-          <a href="${process.env.FRONTEND_URL}/unsubscribe">Unsubscribe</a>
-        </p>
-      </div>
-    `
-  }
-
-  private getInvitationTemplate(
-    groupName: string,
-    inviterName: string,
-    inviteLink: string
-  ): string {
-    return `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #4F46E5;">You're Invited!</h2>
-        <p><strong>${inviterName}</strong> has invited you to join <strong>${groupName}</strong>.</p>
-        <p>Join this savings group to start building wealth together.</p>
-        <a href="${inviteLink}" style="display: inline-block; padding: 12px 24px; background: #4F46E5; color: white; text-decoration: none; border-radius: 6px; margin: 20px 0;">Accept Invitation</a>
-        <p style="color: #666; font-size: 12px; margin-top: 40px;">
-          <a href="${process.env.FRONTEND_URL}/unsubscribe">Unsubscribe</a>
-        </p>
-      </div>
-    `
-  }
-
-  private getWeeklySummaryTemplate(data: {
-    groupName: string
-    contributions: number
-    balance: string
-  }): string {
-    return `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #4F46E5;">Your Weekly Summary</h2>
-        <p>Here's your activity for <strong>${data.groupName}</strong> this week.</p>
-        <div style="background: #F3F4F6; padding: 20px; border-radius: 8px; margin: 20px 0;">
-          <p><strong>Contributions:</strong> ${data.contributions}</p>
-          <p><strong>Balance:</strong> ${data.balance}</p>
-        </div>
-        <a href="${process.env.FRONTEND_URL}/dashboard" style="display: inline-block; padding: 12px 24px; background: #4F46E5; color: white; text-decoration: none; border-radius: 6px;">View Dashboard</a>
-        <p style="color: #666; font-size: 12px; margin-top: 40px;">
-          <a href="${process.env.FRONTEND_URL}/unsubscribe">Unsubscribe</a>
-        </p>
-      </div>
-    `
-  }
-
-  private getReceiptTemplate(data: {
-    groupName: string
-    amount: string
-    txHash: string
-    date: string
-  }): string {
-    return `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #4F46E5;">Transaction Receipt</h2>
-        <p>Your contribution has been recorded.</p>
-        <div style="background: #F3F4F6; padding: 20px; border-radius: 8px; margin: 20px 0;">
-          <p><strong>Group:</strong> ${data.groupName}</p>
-          <p><strong>Amount:</strong> ${data.amount}</p>
-          <p><strong>Date:</strong> ${data.date}</p>
-          <p><strong>Transaction:</strong> <code style="font-size: 11px;">${data.txHash}</code></p>
-        </div>
-        <a href="${process.env.FRONTEND_URL}/transactions/${data.txHash}" style="display: inline-block; padding: 12px 24px; background: #4F46E5; color: white; text-decoration: none; border-radius: 6px;">View Transaction</a>
-        <p style="color: #666; font-size: 12px; margin-top: 40px;">
-          <a href="${process.env.FRONTEND_URL}/unsubscribe">Unsubscribe</a>
-        </p>
-      </div>
-    `
-  }
-
-  private getVerificationTemplate(verifyLink: string): string {
-    return `
-      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-        <h2 style="color: #4F46E5;">Verify Your Email</h2>
-        <p>Please verify your email address to complete your registration.</p>
-        <a href="${verifyLink}" style="display: inline-block; padding: 12px 24px; background: #4F46E5; color: white; text-decoration: none; border-radius: 6px; margin: 20px 0;">Verify Email</a>
-        <p style="color: #666; font-size: 12px;">This link expires in 24 hours.</p>
-        <p style="color: #666; font-size: 12px; margin-top: 40px;">
-          If you didn't request this, please ignore this email.
-        </p>
-      </div>
-    `
+    const verifyLink = `${this.frontendUrl}/verify-email?token=${token}`
+    const html = renderTemplate('emailVerification', { verifyLink })
+    return this.sendEmail({ to, subject: 'Verify Your Email', html })
   }
 }
 


### PR DESCRIPTION
feat(backend): implement MJML email templates system

Replaces the inline HTML string templates in emailService.ts with a proper MJML-based template system — responsive, maintainable, and consistent across email clients.

New files

backend/src/emails/ — template directory:

welcome.mjml — onboarding email with 3-step getting started guide and dashboard CTA
contributionReminder.mjml — amber-themed reminder with group name, amount, due date, and cycle number in a highlighted details box
payoutNotification.mjml — green-themed payout confirmation with hero amount display and transaction details
groupInvitation.mjml — invitation card showing group details (contribution amount, cycle length, member count) with accept CTA
transactionReceipt.mjml — contribution receipt with full transaction details table and Stellar explorer link
weeklySummary.mjml — 3-stat header row (active groups, total saved, contributions) with per-group activity rows injected at render time
emailVerification.mjml — verification email with button + plain-text URL fallback, 24-hour expiry note
templateEngine.ts
 — the engine:

renderTemplate(name, vars) — compiles MJML → HTML (cached in memory after first compile), then injects {{variable}} placeholders
htmlToText(html) — strips tags for plain-text fallback
buildGroupRows(groups) — generates the weekly summary group table rows
Typed *Vars interfaces for every template ensuring compile-time safety
clearTemplateCache() for test isolation
Updated files

emailService.ts — all 7 send methods now call renderTemplate() instead of inline strings; method signatures extended with cycleNumber, groupId, and richer groupDetails where needed
emailQueue.ts — added the missing queueEmail helper object (custom, welcome, contributionReminder, payoutNotification, transactionReceipt, weeklySummary, verification) that the email controller already imports
All templates share a consistent brand header (indigo #4f46e5), unsubscribe footer, and Inter font stack. Color accents vary by email type (amber for reminders, green for payouts).

Closes #378