### PR TITLE
Add drag-and-drop file upload for profile and group images

### DIFF
--- a/frontend/src/components/upload/FileUpload.tsx
+++ b/frontend/src/components/upload/FileUpload.tsx
@@ -1,0 +1,188 @@
+import React, { useRef, useCallback, useEffect, useState, DragEvent, ChangeEvent } from 'react'
+import { Upload, Loader2 } from 'lucide-react'
+import clsx from 'clsx'
+import { ImagePreview } from './ImagePreview'
+import { useFileUpload, FileUploadOptions } from '../../hooks/useFileUpload'
+
+export interface FileUploadProps extends FileUploadOptions {
+  variant?: 'avatar' | 'group'
+  size?: 'sm' | 'md' | 'lg'
+  label?: string
+  disabled?: boolean
+  className?: string
+  onSuccess?: (url: string) => void
+}
+
+export const FileUpload: React.FC<FileUploadProps> = ({
+  variant = 'avatar',
+  size = 'md',
+  label,
+  disabled = false,
+  className,
+  onSuccess,
+  onUpload,
+  maxSizeBytes,
+  acceptedTypes,
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [isDragging, setIsDragging] = useState(false)
+
+  const { file, previewUrl, isUploading, error, handleFile, upload, reset } = useFileUpload({
+    maxSizeBytes,
+    acceptedTypes,
+    onUpload,
+  })
+
+  // Auto-upload when a file is selected and onUpload handler is provided
+  useEffect(() => {
+    if (!file || !onUpload) return
+    upload().then((url) => {
+      if (url && onSuccess) onSuccess(url)
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [file])
+
+  const onInputChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const selected = e.target.files?.[0]
+      if (selected) handleFile(selected)
+      e.target.value = ''
+    },
+    [handleFile],
+  )
+
+  const onDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    if (!disabled) setIsDragging(true)
+  }
+
+  const onDragLeave = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsDragging(false)
+  }
+
+  const onDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    setIsDragging(false)
+    if (disabled) return
+    const dropped = e.dataTransfer.files?.[0]
+    if (dropped) handleFile(dropped)
+  }
+
+  const openFilePicker = () => {
+    if (!disabled && !isUploading) inputRef.current?.click()
+  }
+
+  const isAvatar = variant === 'avatar'
+  const accept = (acceptedTypes ?? ['image/jpeg', 'image/png', 'image/webp', 'image/gif']).join(',')
+
+  return (
+    <div className={clsx('flex flex-col items-center gap-3', className)}>
+      {label && (
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</span>
+      )}
+
+      <div
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-label={`Upload ${isAvatar ? 'profile picture' : 'group image'}`}
+        aria-disabled={disabled || isUploading}
+        onClick={openFilePicker}
+        onKeyDown={(e: React.KeyboardEvent) =>
+          (e.key === 'Enter' || e.key === ' ') && openFilePicker()
+        }
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        className={clsx(
+          'relative cursor-pointer select-none',
+          'focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+          isAvatar ? 'rounded-full' : 'rounded-xl',
+          isDragging && 'ring-2 ring-primary-500 ring-offset-2',
+          (disabled || isUploading) && 'cursor-not-allowed opacity-60',
+        )}
+      >
+        <ImagePreview
+          src={previewUrl}
+          onRemove={
+            previewUrl
+              ? () => {
+                  reset()
+                }
+              : undefined
+          }
+          variant={variant}
+          size={size}
+        />
+
+        {/* Hover overlay — no image */}
+        {!previewUrl && (
+          <div
+            className={clsx(
+              'absolute inset-0 flex items-center justify-center',
+              'opacity-0 hover:opacity-100 transition-opacity',
+              isAvatar ? 'rounded-full' : 'rounded-xl',
+              'bg-black/30',
+            )}
+            aria-hidden="true"
+          >
+            <Upload size={16} className="text-white" />
+          </div>
+        )}
+
+        {/* Hover overlay — has image */}
+        {previewUrl && !isUploading && (
+          <div
+            className={clsx(
+              'absolute inset-0 flex flex-col items-center justify-center gap-1',
+              'opacity-0 hover:opacity-100 transition-opacity',
+              isAvatar ? 'rounded-full' : 'rounded-xl',
+              'bg-black/40',
+            )}
+            aria-hidden="true"
+          >
+            <Upload size={16} className="text-white" />
+            <span className="text-white text-xs font-medium">Change</span>
+          </div>
+        )}
+
+        {/* Upload spinner */}
+        {isUploading && (
+          <div
+            className={clsx(
+              'absolute inset-0 flex items-center justify-center',
+              isAvatar ? 'rounded-full' : 'rounded-xl',
+              'bg-black/50',
+            )}
+            aria-label="Uploading"
+          >
+            <Loader2 size={20} className="text-white animate-spin" aria-hidden="true" />
+          </div>
+        )}
+      </div>
+
+      {!previewUrl && (
+        <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+          Click or drag &amp; drop to upload
+        </p>
+      )}
+
+      {error && (
+        <p role="alert" className="text-xs text-red-500 dark:text-red-400 text-center max-w-[200px]">
+          {error}
+        </p>
+      )}
+
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        onChange={onInputChange}
+        className="sr-only"
+        aria-hidden="true"
+        tabIndex={-1}
+        disabled={disabled || isUploading}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/upload/ImagePreview.tsx
+++ b/frontend/src/components/upload/ImagePreview.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { X, User, Users } from 'lucide-react'
+import clsx from 'clsx'
+
+export interface ImagePreviewProps {
+  src: string | null
+  onRemove?: () => void
+  variant?: 'avatar' | 'group'
+  size?: 'sm' | 'md' | 'lg'
+  className?: string
+}
+
+const sizeStyles: Record<string, string> = {
+  sm: 'w-16 h-16',
+  md: 'w-24 h-24',
+  lg: 'w-32 h-32',
+}
+
+const iconSizes: Record<string, number> = {
+  sm: 24,
+  md: 32,
+  lg: 40,
+}
+
+export const ImagePreview: React.FC<ImagePreviewProps> = ({
+  src,
+  onRemove,
+  variant = 'avatar',
+  size = 'md',
+  className,
+}) => {
+  const isAvatar = variant === 'avatar'
+  const PlaceholderIcon = isAvatar ? User : Users
+
+  return (
+    <div
+      className={clsx(
+        'relative inline-flex items-center justify-center flex-shrink-0',
+        sizeStyles[size],
+        className,
+      )}
+    >
+      {src ? (
+        <img
+          src={src}
+          alt="Preview"
+          className={clsx(
+            'w-full h-full object-cover',
+            isAvatar ? 'rounded-full' : 'rounded-xl',
+            'border-2 border-gray-200 dark:border-gray-700',
+          )}
+        />
+      ) : (
+        <div
+          className={clsx(
+            'w-full h-full flex items-center justify-center',
+            'bg-gray-100 dark:bg-gray-800',
+            'border-2 border-dashed border-gray-300 dark:border-gray-600',
+            isAvatar ? 'rounded-full' : 'rounded',
+          )}
+          aria-label={isAvatar ? 'No profile picture' : 'No group image'}
+        >
+          <PlaceholderIcon
+            size={iconSizes[size]}
+            className="text-gray-400 dark:text-gray-500"
+            aria-hidden="true"
+          />
+        </div>
+      )}
+
+      {src && onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label="Remove image"
+          className={clsx(
+            'absolute -top-1 -right-1',
+            'w-5 h-5 rounded-full',
+            'bg-red-500 hover:bg-red-600',
+            'text-white flex items-center justify-center',
+            'transition-colors focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1',
+          )}
+        >
+          <X size={12} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useFileUpload.ts
+++ b/frontend/src/hooks/useFileUpload.ts
@@ -1,0 +1,88 @@
+import { useState, useCallback } from 'react'
+
+export interface FileUploadOptions {
+  maxSizeBytes?: number
+  acceptedTypes?: string[]
+  onUpload?: (file: File) => Promise<string>
+}
+
+export interface FileUploadState {
+  file: File | null
+  previewUrl: string | null
+  isUploading: boolean
+  error: string | null
+  uploadedUrl: string | null
+}
+
+export interface UseFileUploadReturn extends FileUploadState {
+  handleFile: (file: File) => void
+  upload: () => Promise<string | null>
+  reset: () => void
+}
+
+const DEFAULT_MAX_SIZE = 5 * 1024 * 1024 // 5MB
+const DEFAULT_ACCEPTED_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif']
+
+export function useFileUpload(options: FileUploadOptions = {}): UseFileUploadReturn {
+  const {
+    maxSizeBytes = DEFAULT_MAX_SIZE,
+    acceptedTypes = DEFAULT_ACCEPTED_TYPES,
+    onUpload,
+  } = options
+
+  const [state, setState] = useState<FileUploadState>({
+    file: null,
+    previewUrl: null,
+    isUploading: false,
+    error: null,
+    uploadedUrl: null,
+  })
+
+  const handleFile = useCallback(
+    (file: File) => {
+      if (!acceptedTypes.includes(file.type)) {
+        setState((prev: FileUploadState) => ({
+          ...prev,
+          error: `File type not supported. Accepted: ${acceptedTypes.map((t) => t.split('/')[1]).join(', ')}`,
+        }))
+        return
+      }
+
+      if (file.size > maxSizeBytes) {
+        const maxMB = (maxSizeBytes / (1024 * 1024)).toFixed(0)
+        setState((prev: FileUploadState) => ({
+          ...prev,
+          error: `File too large. Maximum size is ${maxMB}MB`,
+        }))
+        return
+      }
+
+      const previewUrl = URL.createObjectURL(file)
+      setState({ file, previewUrl, isUploading: false, error: null, uploadedUrl: null })
+    },
+    [acceptedTypes, maxSizeBytes],
+  )
+
+  const upload = useCallback(async (): Promise<string | null> => {
+    if (!state.file || !onUpload) return null
+
+    setState((prev: FileUploadState) => ({ ...prev, isUploading: true, error: null }))
+
+    try {
+      const url = await onUpload(state.file)
+      setState((prev: FileUploadState) => ({ ...prev, isUploading: false, uploadedUrl: url }))
+      return url
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Upload failed'
+      setState((prev: FileUploadState) => ({ ...prev, isUploading: false, error: message }))
+      return null
+    }
+  }, [state.file, onUpload])
+
+  const reset = useCallback(() => {
+    if (state.previewUrl) URL.revokeObjectURL(state.previewUrl)
+    setState({ file: null, previewUrl: null, isUploading: false, error: null, uploadedUrl: null })
+  }, [state.previewUrl])
+
+  return { ...state, handleFile, upload, reset }
+}


### PR DESCRIPTION
## Summary

Implements drag-and-drop file upload with live preview for profile pictures and group images.

### Changes:

1. useFileUpload.ts — hook handling file validation (type + size), object URL preview generation, upload state, and cleanup on reset
2. ImagePreview.tsx — displays the preview with avatar (circular) and group (rounded rect) variants, placeholder icons, and a remove button
3. FileUpload.tsx — drop zone component with drag-and-drop, click-to-browse, hover overlays, upload spinner, and inline error messages. Auto-triggers upload via onUpload callback and fires onSuccess with the returned URL


Accepted formats: JPEG, PNG, WebP, GIF — max 5MB by default (configurable).

this pr Closes #451 