### PR TITLE
feat: standardize pagination with offset and cursor-based support

### DIFF
--- a/backend/src/middleware/paginate.ts
+++ b/backend/src/middleware/paginate.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction } from 'express'
+import { parseOffsetParams, parseCursorParams } from '../utils/pagination'
+import { PaginationParams } from '../types/pagination'
+
+declare global {
+  namespace Express {
+    interface Request {
+      pagination?: PaginationParams
+    }
+  }
+}
+
+/**
+ * Middleware that parses pagination query params and attaches them to `req.pagination`.
+ *
+ * Offset mode (default):  ?page=1&limit=20
+ * Cursor mode:            ?cursor=<id>&limit=20&strategy=cursor
+ */
+export function paginateMiddleware(req: Request, _res: Response, next: NextFunction): void {
+  const strategy = req.query.strategy === 'cursor' ? 'cursor' : 'offset'
+
+  req.pagination =
+    strategy === 'cursor'
+      ? parseCursorParams(req.query as Record<string, unknown>)
+      : parseOffsetParams(req.query as Record<string, unknown>)
+
+  next()
+}

--- a/backend/src/types/pagination.ts
+++ b/backend/src/types/pagination.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared pagination types supporting both offset-based and cursor-based strategies.
+ */
+
+export type PaginationStrategy = 'offset' | 'cursor'
+
+// --- Offset-based ---
+
+export interface OffsetPaginationParams {
+  strategy: 'offset'
+  page: number
+  limit: number
+}
+
+export interface OffsetPaginationMeta {
+  strategy: 'offset'
+  page: number
+  limit: number
+  total: number
+  totalPages: number
+  hasNextPage: boolean
+  hasPrevPage: boolean
+}
+
+// --- Cursor-based ---
+
+export interface CursorPaginationParams {
+  strategy: 'cursor'
+  cursor?: string
+  limit: number
+  direction?: 'forward' | 'backward'
+}
+
+export interface CursorPaginationMeta {
+  strategy: 'cursor'
+  limit: number
+  nextCursor: string | null
+  prevCursor: string | null
+  hasNextPage: boolean
+  hasPrevPage: boolean
+}
+
+// --- Union types ---
+
+export type PaginationParams = OffsetPaginationParams | CursorPaginationParams
+export type PaginationMeta = OffsetPaginationMeta | CursorPaginationMeta
+
+export interface PaginatedResponse<T> {
+  data: T[]
+  pagination: PaginationMeta
+}

--- a/backend/src/utils/pagination.ts
+++ b/backend/src/utils/pagination.ts
@@ -1,0 +1,86 @@
+import {
+  OffsetPaginationParams,
+  CursorPaginationParams,
+  OffsetPaginationMeta,
+  CursorPaginationMeta,
+  PaginatedResponse,
+} from '../types/pagination'
+
+const DEFAULT_LIMIT = 20
+const MAX_LIMIT = 100
+
+// --- Offset helpers ---
+
+export function parseOffsetParams(query: Record<string, unknown>): OffsetPaginationParams {
+  const page = Math.max(1, parseInt(String(query.page ?? 1), 10) || 1)
+  const limit = Math.min(MAX_LIMIT, Math.max(1, parseInt(String(query.limit ?? DEFAULT_LIMIT), 10) || DEFAULT_LIMIT))
+  return { strategy: 'offset', page, limit }
+}
+
+export function buildOffsetMeta(
+  params: OffsetPaginationParams,
+  total: number
+): OffsetPaginationMeta {
+  const totalPages = Math.ceil(total / params.limit) || 0
+  return {
+    strategy: 'offset',
+    page: params.page,
+    limit: params.limit,
+    total,
+    totalPages,
+    hasNextPage: params.page < totalPages,
+    hasPrevPage: params.page > 1,
+  }
+}
+
+export function applyOffsetPagination<T>(
+  items: T[],
+  params: OffsetPaginationParams
+): PaginatedResponse<T> {
+  const total = items.length
+  const offset = (params.page - 1) * params.limit
+  return {
+    data: items.slice(offset, offset + params.limit),
+    pagination: buildOffsetMeta(params, total),
+  }
+}
+
+export function offsetToSkipTake(params: OffsetPaginationParams): { skip: number; take: number } {
+  return {
+    skip: (params.page - 1) * params.limit,
+    take: params.limit,
+  }
+}
+
+// --- Cursor helpers ---
+
+export function parseCursorParams(query: Record<string, unknown>): CursorPaginationParams {
+  const limit = Math.min(MAX_LIMIT, Math.max(1, parseInt(String(query.limit ?? DEFAULT_LIMIT), 10) || DEFAULT_LIMIT))
+  const cursor = query.cursor ? String(query.cursor) : undefined
+  const direction = query.direction === 'backward' ? 'backward' : 'forward'
+  return { strategy: 'cursor', cursor, limit, direction }
+}
+
+/**
+ * Builds cursor pagination meta from a result set.
+ * Fetches `limit + 1` items to detect next page; caller passes that raw slice.
+ */
+export function buildCursorMeta<T extends { id: string }>(
+  items: T[],
+  params: CursorPaginationParams
+): { data: T[]; pagination: CursorPaginationMeta } {
+  const hasNextPage = items.length > params.limit
+  const data = hasNextPage ? items.slice(0, params.limit) : items
+
+  return {
+    data,
+    pagination: {
+      strategy: 'cursor',
+      limit: params.limit,
+      nextCursor: hasNextPage ? data[data.length - 1]?.id ?? null : null,
+      prevCursor: params.cursor ?? null,
+      hasNextPage,
+      hasPrevPage: !!params.cursor,
+    },
+  }
+}


### PR DESCRIPTION
- Add PaginationParams/Meta/PaginatedResponse types
- Add parseOffsetParams, buildOffsetMeta, applyOffsetPagination, offsetToSkipTake helpers
- Add parseCursorParams, buildCursorMeta helpers
- Add paginateMiddleware that auto-detects strategy from ?strategy=cursor|offset
- Supports ?page&limit (offset) and ?cursor&limit (cursor) query params
closes #498