### PR TITLE
feat: implement repository pattern to abstract database access

### DIFF
--- a/backend/src/controllers/goalsController.ts
+++ b/backend/src/controllers/goalsController.ts
@@ -1,9 +1,10 @@
 import { Request, Response } from 'express'
-import { PrismaClient } from '@prisma/client'
 import { asyncHandler } from '../middleware/errorHandler'
 import { AppError } from '../errors/AppError'
+import { GoalRepository } from '../repositories/GoalRepository'
+import { prisma } from '../config/database'
 
-const prisma = new PrismaClient()
+const goalRepo = new GoalRepository(prisma)
 
 const serializeBigInt = (data: unknown) =>
   JSON.parse(JSON.stringify(data, (_, v) => (typeof v === 'bigint' ? v.toString() : v)))
@@ -15,17 +16,15 @@ export class GoalsController {
 
     const { title, description, targetAmount, deadline, category, isPublic } = req.body
 
-    const goal = await prisma.goal.create({
-      data: {
-        title,
-        description,
-        targetAmount: BigInt(targetAmount),
-        deadline: new Date(deadline),
-        category,
-        isPublic: isPublic ?? false,
-        userId,
-        currentAmount: BigInt(0),
-      },
+    const goal = await goalRepo.create({
+      title,
+      description,
+      targetAmount: BigInt(targetAmount),
+      deadline: new Date(deadline),
+      category,
+      isPublic: isPublic ?? false,
+      userId,
+      currentAmount: BigInt(0),
     })
 
     res.status(201).json({ success: true, data: serializeBigInt(goal) })
@@ -35,17 +34,14 @@ export class GoalsController {
     const userId = (req as any).user?.publicKey || req.query.userId
     if (!userId) throw new AppError('User ID is required', 'UNAUTHORIZED', 401)
 
-    const goals = await prisma.goal.findMany({
-      where: { userId: String(userId) },
-      orderBy: { createdAt: 'desc' },
-    })
+    const goals = await goalRepo.findByUser(String(userId))
 
     res.status(200).json({ success: true, data: serializeBigInt(goals) })
   })
 
   getGoal = asyncHandler(async (req: Request, res: Response) => {
     const { id } = req.params
-    const goal = await prisma.goal.findUnique({ where: { id }, include: { members: true } })
+    const goal = await goalRepo.findWithMembers(id)
 
     if (!goal) throw new AppError('Goal not found', 'NOT_FOUND', 404)
 
@@ -56,17 +52,14 @@ export class GoalsController {
     const { id } = req.params
     const { title, description, targetAmount, deadline, category, isPublic, status } = req.body
 
-    const goal = await prisma.goal.update({
-      where: { id },
-      data: {
-        ...(title !== undefined && { title }),
-        ...(description !== undefined && { description }),
-        ...(targetAmount !== undefined && { targetAmount: BigInt(targetAmount) }),
-        ...(deadline !== undefined && { deadline: new Date(deadline) }),
-        ...(category !== undefined && { category }),
-        ...(isPublic !== undefined && { isPublic }),
-        ...(status !== undefined && { status }),
-      },
+    const goal = await goalRepo.update(id, {
+      ...(title !== undefined && { title }),
+      ...(description !== undefined && { description }),
+      ...(targetAmount !== undefined && { targetAmount: BigInt(targetAmount) }),
+      ...(deadline !== undefined && { deadline: new Date(deadline) }),
+      ...(category !== undefined && { category }),
+      ...(isPublic !== undefined && { isPublic }),
+      ...(status !== undefined && { status }),
     })
 
     res.status(200).json({ success: true, data: serializeBigInt(goal) })
@@ -74,7 +67,7 @@ export class GoalsController {
 
   deleteGoal = asyncHandler(async (req: Request, res: Response) => {
     const { id } = req.params
-    await prisma.goal.delete({ where: { id } })
+    await goalRepo.delete(id)
     res.status(200).json({ success: true, message: 'Goal deleted successfully' })
   })
 

--- a/backend/src/repositories/BaseRepository.ts
+++ b/backend/src/repositories/BaseRepository.ts
@@ -1,0 +1,41 @@
+import { PrismaClient } from '@prisma/client'
+import { FindOptions, IRepository } from './interfaces/IRepository'
+
+/**
+ * Abstract base repository providing common CRUD operations.
+ * Concrete repositories extend this and implement `get model()`.
+ */
+export abstract class BaseRepository<T> implements IRepository<T> {
+  constructor(protected readonly prisma: PrismaClient) {}
+
+  async findById(id: string): Promise<T | null> {
+    return (this.model.findUnique({ where: { id } }) as Promise<T | null>)
+  }
+
+  async findAll(options: FindOptions = {}): Promise<T[]> {
+    return (this.model.findMany(options) as Promise<T[]>)
+  }
+
+  async create(data: unknown): Promise<T> {
+    return (this.model.create({ data }) as Promise<T>)
+  }
+
+  async update(id: string, data: unknown): Promise<T> {
+    return (this.model.update({ where: { id }, data }) as Promise<T>)
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.model.delete({ where: { id } })
+  }
+
+  async count(where?: Record<string, unknown>): Promise<number> {
+    return this.model.count({ where })
+  }
+
+  async findOne(where: Record<string, unknown>): Promise<T | null> {
+    return (this.model.findFirst({ where }) as Promise<T | null>)
+  }
+
+  /** Subclasses return the Prisma delegate for their model, e.g. `this.prisma.user` */
+  protected abstract get model(): any
+}

--- a/backend/src/repositories/GoalRepository.ts
+++ b/backend/src/repositories/GoalRepository.ts
@@ -1,0 +1,47 @@
+import { PrismaClient, Goal } from '@prisma/client'
+import { BaseRepository } from './BaseRepository'
+
+export class GoalRepository extends BaseRepository<Goal> {
+  constructor(prisma: PrismaClient) {
+    super(prisma)
+  }
+
+  protected get model() {
+    return this.prisma.goal
+  }
+
+  async findByUser(userId: string): Promise<Goal[]> {
+    return this.prisma.goal.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    })
+  }
+
+  async findPublic(): Promise<Goal[]> {
+    return this.prisma.goal.findMany({
+      where: { isPublic: true, status: 'ACTIVE' },
+      orderBy: { createdAt: 'desc' },
+    })
+  }
+
+  async findWithMembers(id: string): Promise<(Goal & { members: unknown[] }) | null> {
+    return this.prisma.goal.findUnique({
+      where: { id },
+      include: { members: true },
+    }) as Promise<any>
+  }
+
+  async updateAmount(id: string, amount: bigint): Promise<Goal> {
+    return this.prisma.goal.update({
+      where: { id },
+      data: { currentAmount: amount },
+    })
+  }
+
+  async findByStatus(userId: string, status: string): Promise<Goal[]> {
+    return this.prisma.goal.findMany({
+      where: { userId, status },
+      orderBy: { deadline: 'asc' },
+    })
+  }
+}

--- a/backend/src/repositories/GroupRepository.ts
+++ b/backend/src/repositories/GroupRepository.ts
@@ -1,0 +1,42 @@
+import { PrismaClient, Group } from '@prisma/client'
+import { BaseRepository } from './BaseRepository'
+
+export class GroupRepository extends BaseRepository<Group> {
+  constructor(prisma: PrismaClient) {
+    super(prisma)
+  }
+
+  protected get model() {
+    return this.prisma.group
+  }
+
+  async findActive(): Promise<Group[]> {
+    return this.prisma.group.findMany({ where: { isActive: true } })
+  }
+
+  async findWithMembers(id: string): Promise<(Group & { members: unknown[] }) | null> {
+    return this.prisma.group.findUnique({
+      where: { id },
+      include: { members: { include: { user: true } } },
+    }) as Promise<any>
+  }
+
+  async findWithContributions(id: string): Promise<(Group & { contributions: unknown[] }) | null> {
+    return this.prisma.group.findUnique({
+      where: { id },
+      include: { contributions: true },
+    }) as Promise<any>
+  }
+
+  async findByMember(walletAddress: string): Promise<Group[]> {
+    const memberships = await this.prisma.groupMember.findMany({
+      where: { userId: walletAddress },
+      include: { group: true },
+    })
+    return memberships.map((m: { group: Group }) => m.group)
+  }
+
+  async countMembers(groupId: string): Promise<number> {
+    return this.prisma.groupMember.count({ where: { groupId } })
+  }
+}

--- a/backend/src/repositories/UserRepository.ts
+++ b/backend/src/repositories/UserRepository.ts
@@ -1,0 +1,41 @@
+import { PrismaClient, User } from '@prisma/client'
+import { BaseRepository } from './BaseRepository'
+
+export class UserRepository extends BaseRepository<User> {
+  constructor(prisma: PrismaClient) {
+    super(prisma)
+  }
+
+  protected get model() {
+    return this.prisma.user
+  }
+
+  async findByWalletAddress(walletAddress: string): Promise<User | null> {
+    return this.prisma.user.findUnique({ where: { walletAddress } })
+  }
+
+  async upsertByWalletAddress(
+    walletAddress: string,
+    data: Partial<Omit<User, 'id' | 'createdAt' | 'updatedAt'>>
+  ): Promise<User> {
+    return this.prisma.user.upsert({
+      where: { walletAddress },
+      create: { walletAddress, ...data },
+      update: data,
+    })
+  }
+
+  async findWithMetrics(walletAddress: string): Promise<User & { metrics: unknown } | null> {
+    return this.prisma.user.findUnique({
+      where: { walletAddress },
+      include: { metrics: true },
+    }) as Promise<any>
+  }
+
+  async findWithGroups(walletAddress: string): Promise<User & { groups: unknown[] } | null> {
+    return this.prisma.user.findUnique({
+      where: { walletAddress },
+      include: { groups: { include: { group: true } } },
+    }) as Promise<any>
+  }
+}

--- a/backend/src/repositories/index.ts
+++ b/backend/src/repositories/index.ts
@@ -1,0 +1,5 @@
+export { BaseRepository } from './BaseRepository'
+export { UserRepository } from './UserRepository'
+export { GroupRepository } from './GroupRepository'
+export { GoalRepository } from './GoalRepository'
+export type { IRepository, FindOptions } from './interfaces/IRepository'

--- a/backend/src/repositories/interfaces/IRepository.ts
+++ b/backend/src/repositories/interfaces/IRepository.ts
@@ -1,0 +1,15 @@
+export interface FindOptions {
+  where?: Record<string, unknown>
+  orderBy?: Record<string, 'asc' | 'desc'>
+  skip?: number
+  take?: number
+  include?: Record<string, unknown>
+}
+
+export interface IRepository<T> {
+  findById(id: string): Promise<T | null>
+  findAll(options?: FindOptions): Promise<T[]>
+  create(data: unknown): Promise<T>
+  update(id: string, data: unknown): Promise<T>
+  delete(id: string): Promise<void>
+}


### PR DESCRIPTION
- Add BaseRepository<T> with generic CRUD + count/findOne
- Add UserRepository with wallet-address lookups and upsert
- Add GroupRepository with member/contribution queries
- Add GoalRepository with user/status/public queries
- Refactor GoalsController to use GoalRepository instead of raw Prisma
- Add IRepository interface for testability

closes #477