### PR TITLE
feat(contracts): add predefined group templates for common savings use cases

### DIFF
--- a/contracts/ajo/src/contract.rs
+++ b/contracts/ajo/src/contract.rs
@@ -2484,4 +2484,77 @@ pub fn get_refund_record(
     pub fn get_group_disputes(env: Env, group_id: u64) -> Vec<u64> {
         storage::get_group_dispute_ids(&env, group_id)
     }
+
+    // ── Group templates ───────────────────────────────────────────────────
+
+    /// Create a group using a predefined template.
+    ///
+    /// Applies the template's default cycle duration, grace period, and penalty
+    /// rate while letting the caller choose the contribution amount and member cap.
+    /// The contribution amount must be at least the template's
+    /// `suggested_contribution_min`.
+    ///
+    /// # Arguments
+    /// * `env`                  - The Soroban contract environment
+    /// * `creator`              - Address of the group creator
+    /// * `token_address`        - Token contract address for contributions/payouts
+    /// * `template`             - The [`GroupTemplate`] to apply
+    /// * `contribution_amount`  - Contribution per cycle in stroops (≥ template min)
+    /// * `max_members`          - Maximum members (2–100)
+    ///
+    /// # Returns
+    /// The unique group ID of the newly created group.
+    ///
+    /// # Errors
+    /// * `ContributionAmountZero` – if `contribution_amount` is below the template minimum
+    /// * Standard [`create_group`] errors for invalid parameters
+    pub fn create_group_from_template(
+        env: Env,
+        creator: Address,
+        token_address: Address,
+        template: crate::types::GroupTemplate,
+        contribution_amount: i128,
+        max_members: u32,
+    ) -> Result<u64, AjoError> {
+        let config = utils::get_template_config(template);
+
+        // Enforce template minimum contribution
+        if contribution_amount < config.suggested_contribution_min {
+            return Err(AjoError::ContributionAmountZero);
+        }
+
+        Self::create_group(
+            env,
+            creator,
+            token_address,
+            contribution_amount,
+            config.default_cycle_duration,
+            max_members,
+            config.default_grace_period,
+            config.default_penalty_rate,
+            0, // No insurance by default
+        )
+    }
+
+    /// Return the [`TemplateConfig`] for a given [`GroupTemplate`].
+    ///
+    /// Useful for clients that want to display template defaults before
+    /// asking the user to confirm or customise parameters.
+    pub fn get_template_config(
+        _env: Env,
+        template: crate::types::GroupTemplate,
+    ) -> crate::types::TemplateConfig {
+        utils::get_template_config(template)
+    }
+
+    /// Return all available [`GroupTemplate`] variants.
+    pub fn list_available_templates(env: Env) -> Vec<crate::types::GroupTemplate> {
+        let mut templates = Vec::new(&env);
+        templates.push_back(crate::types::GroupTemplate::MonthlySavings);
+        templates.push_back(crate::types::GroupTemplate::WeeklySavings);
+        templates.push_back(crate::types::GroupTemplate::EmergencyFund);
+        templates.push_back(crate::types::GroupTemplate::InvestmentClub);
+        templates.push_back(crate::types::GroupTemplate::Custom);
+        templates
+    }
 }

--- a/contracts/ajo/src/lib.rs
+++ b/contracts/ajo/src/lib.rs
@@ -32,3 +32,4 @@ pub use types::{ReminderType, MemberNotificationPreferences, ReminderRecord};
 pub use types::{GroupMilestone, MemberAchievement, MilestoneRecord, AchievementRecord, MemberStats};
 pub use types::{TokenConfig, MultiTokenConfig, TokenContribution};
 pub use types::{Dispute, DisputeType, DisputeStatus, DisputeResolution, DisputeVote};
+pub use types::{GroupTemplate, TemplateConfig};

--- a/contracts/ajo/src/types.rs
+++ b/contracts/ajo/src/types.rs
@@ -666,3 +666,46 @@ pub struct TokenContribution {
 
 /// Maximum number of distinct tokens a multi-token group can accept.
 pub const MAX_ACCEPTED_TOKENS: u32 = 10;
+
+// ── Group templates ───────────────────────────────────────────────────────
+
+/// Predefined group templates for common savings use cases.
+///
+/// Each variant maps to a [`TemplateConfig`] with sensible defaults that
+/// callers can override when creating a group via
+/// [`AjoContract::create_group_from_template`].
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum GroupTemplate {
+    /// 30-day cycles, moderate contribution amounts, up to 12 members.
+    MonthlySavings = 0,
+    /// 7-day cycles, smaller contribution amounts, up to 10 members.
+    WeeklySavings = 1,
+    /// 14-day cycles, higher contribution amounts, lower penalty rate.
+    EmergencyFund = 2,
+    /// 90-day cycles, larger contribution amounts, up to 20 members.
+    InvestmentClub = 3,
+    /// Fully customizable — no opinionated defaults beyond the minimums.
+    Custom = 4,
+}
+
+/// Pre-configured defaults and suggested ranges for a [`GroupTemplate`].
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TemplateConfig {
+    /// The template this config belongs to.
+    pub template_type: GroupTemplate,
+    /// Default cycle duration in seconds.
+    pub default_cycle_duration: u64,
+    /// Default grace period in seconds.
+    pub default_grace_period: u64,
+    /// Default penalty rate as a percentage (0–100).
+    pub default_penalty_rate: u32,
+    /// Suggested minimum contribution amount in stroops.
+    pub suggested_contribution_min: i128,
+    /// Suggested maximum contribution amount in stroops.
+    pub suggested_contribution_max: i128,
+    /// Suggested maximum number of members.
+    pub suggested_max_members: u32,
+}

--- a/contracts/ajo/src/utils.rs
+++ b/contracts/ajo/src/utils.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{Address, Env, Vec};
 
-use crate::types::{Group, GroupMilestone, MemberAchievement, PayoutOrder, PayoutOrderingStrategy};
+use crate::types::{Group, GroupMilestone, GroupTemplate, MemberAchievement, PayoutOrder, PayoutOrderingStrategy, TemplateConfig};
 use crate::errors::AjoError;
 
 /// Returns `true` if `address` appears in the group's `members` list.
@@ -514,4 +514,60 @@ pub fn calculate_equivalent_amount(
 /// Returns `true` if `address` is either the complainant or defendant in a dispute.
 pub fn is_dispute_member(dispute: &crate::types::Dispute, address: &Address) -> bool {
     dispute.complainant == *address || dispute.defendant == *address
+}
+
+// ── Group templates ───────────────────────────────────────────────────────
+
+/// Returns the pre-configured [`TemplateConfig`] for the given [`GroupTemplate`].
+///
+/// All duration values are in seconds; all amounts are in stroops
+/// (1 XLM = 10_000_000 stroops).
+pub fn get_template_config(template: GroupTemplate) -> TemplateConfig {
+    match template {
+        GroupTemplate::MonthlySavings => TemplateConfig {
+            template_type: GroupTemplate::MonthlySavings,
+            default_cycle_duration: 2_592_000,       // 30 days
+            default_grace_period: 86_400,             // 1 day
+            default_penalty_rate: 5,
+            suggested_contribution_min: 10_000_000,   // 1 XLM
+            suggested_contribution_max: 1_000_000_000, // 100 XLM
+            suggested_max_members: 12,
+        },
+        GroupTemplate::WeeklySavings => TemplateConfig {
+            template_type: GroupTemplate::WeeklySavings,
+            default_cycle_duration: 604_800,          // 7 days
+            default_grace_period: 43_200,             // 12 hours
+            default_penalty_rate: 10,
+            suggested_contribution_min: 1_000_000,    // 0.1 XLM
+            suggested_contribution_max: 100_000_000,  // 10 XLM
+            suggested_max_members: 10,
+        },
+        GroupTemplate::EmergencyFund => TemplateConfig {
+            template_type: GroupTemplate::EmergencyFund,
+            default_cycle_duration: 1_209_600,        // 14 days
+            default_grace_period: 172_800,            // 2 days
+            default_penalty_rate: 3,
+            suggested_contribution_min: 50_000_000,   // 5 XLM
+            suggested_contribution_max: 5_000_000_000, // 500 XLM
+            suggested_max_members: 8,
+        },
+        GroupTemplate::InvestmentClub => TemplateConfig {
+            template_type: GroupTemplate::InvestmentClub,
+            default_cycle_duration: 7_776_000,         // 90 days
+            default_grace_period: 604_800,             // 7 days
+            default_penalty_rate: 2,
+            suggested_contribution_min: 100_000_000,   // 10 XLM
+            suggested_contribution_max: 10_000_000_000, // 1000 XLM
+            suggested_max_members: 20,
+        },
+        GroupTemplate::Custom => TemplateConfig {
+            template_type: GroupTemplate::Custom,
+            default_cycle_duration: 2_592_000,
+            default_grace_period: 86_400,
+            default_penalty_rate: 5,
+            suggested_contribution_min: 1_000_000,
+            suggested_contribution_max: 10_000_000_000,
+            suggested_max_members: 50,
+        },
+    }
 }

--- a/contracts/ajo/tests/mod.rs
+++ b/contracts/ajo/tests/mod.rs
@@ -8,6 +8,7 @@ mod multi_token_tests;
 mod payout_ordering_tests;
 mod reminder_tests;
 mod security_tests;
+mod template_tests;
 mod validation_tests;
 
 // additional edge-case tests for duplicate/zero/negative contributions

--- a/contracts/ajo/tests/template_tests.rs
+++ b/contracts/ajo/tests/template_tests.rs
@@ -1,0 +1,233 @@
+#![cfg(test)]
+
+use soroban_ajo::{AjoContract, AjoContractClient, AjoError, GroupTemplate, TemplateConfig};
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup() -> (Env, AjoContractClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, AjoContract);
+    let client = AjoContractClient::new(&env, &contract_id);
+    let creator = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = env.register_stellar_asset_contract(token_admin);
+    (env, client, creator, token)
+}
+
+// ── get_template_config ───────────────────────────────────────────────────
+
+#[test]
+fn test_monthly_savings_config() {
+    let (_env, client, _, _) = setup();
+    let cfg: TemplateConfig = client.get_template_config(&GroupTemplate::MonthlySavings);
+    assert_eq!(cfg.template_type, GroupTemplate::MonthlySavings);
+    assert_eq!(cfg.default_cycle_duration, 2_592_000);
+    assert_eq!(cfg.default_grace_period, 86_400);
+    assert_eq!(cfg.default_penalty_rate, 5);
+    assert_eq!(cfg.suggested_contribution_min, 10_000_000);
+    assert_eq!(cfg.suggested_contribution_max, 1_000_000_000);
+    assert_eq!(cfg.suggested_max_members, 12);
+}
+
+#[test]
+fn test_weekly_savings_config() {
+    let (_env, client, _, _) = setup();
+    let cfg = client.get_template_config(&GroupTemplate::WeeklySavings);
+    assert_eq!(cfg.template_type, GroupTemplate::WeeklySavings);
+    assert_eq!(cfg.default_cycle_duration, 604_800);
+    assert_eq!(cfg.default_grace_period, 43_200);
+    assert_eq!(cfg.default_penalty_rate, 10);
+    assert_eq!(cfg.suggested_max_members, 10);
+}
+
+#[test]
+fn test_emergency_fund_config() {
+    let (_env, client, _, _) = setup();
+    let cfg = client.get_template_config(&GroupTemplate::EmergencyFund);
+    assert_eq!(cfg.template_type, GroupTemplate::EmergencyFund);
+    assert_eq!(cfg.default_cycle_duration, 1_209_600);
+    assert_eq!(cfg.default_grace_period, 172_800);
+    assert_eq!(cfg.default_penalty_rate, 3);
+    assert_eq!(cfg.suggested_max_members, 8);
+}
+
+#[test]
+fn test_investment_club_config() {
+    let (_env, client, _, _) = setup();
+    let cfg = client.get_template_config(&GroupTemplate::InvestmentClub);
+    assert_eq!(cfg.template_type, GroupTemplate::InvestmentClub);
+    assert_eq!(cfg.default_cycle_duration, 7_776_000);
+    assert_eq!(cfg.default_grace_period, 604_800);
+    assert_eq!(cfg.default_penalty_rate, 2);
+    assert_eq!(cfg.suggested_max_members, 20);
+}
+
+#[test]
+fn test_custom_template_config() {
+    let (_env, client, _, _) = setup();
+    let cfg = client.get_template_config(&GroupTemplate::Custom);
+    assert_eq!(cfg.template_type, GroupTemplate::Custom);
+    assert_eq!(cfg.suggested_max_members, 50);
+}
+
+// ── list_available_templates ──────────────────────────────────────────────
+
+#[test]
+fn test_list_available_templates_returns_all_five() {
+    let (_env, client, _, _) = setup();
+    let templates = client.list_available_templates();
+    assert_eq!(templates.len(), 5);
+    assert_eq!(templates.get(0).unwrap(), GroupTemplate::MonthlySavings);
+    assert_eq!(templates.get(1).unwrap(), GroupTemplate::WeeklySavings);
+    assert_eq!(templates.get(2).unwrap(), GroupTemplate::EmergencyFund);
+    assert_eq!(templates.get(3).unwrap(), GroupTemplate::InvestmentClub);
+    assert_eq!(templates.get(4).unwrap(), GroupTemplate::Custom);
+}
+
+// ── create_group_from_template ────────────────────────────────────────────
+
+#[test]
+fn test_create_group_from_monthly_savings_template() {
+    let (_env, client, creator, token) = setup();
+    // 1 XLM = 10_000_000 stroops — exactly at the minimum
+    let group_id = client.create_group_from_template(
+        &creator,
+        &token,
+        &GroupTemplate::MonthlySavings,
+        &10_000_000,
+        &12,
+    );
+    let group = client.get_group(&group_id);
+    assert_eq!(group.cycle_duration, 2_592_000);
+    assert_eq!(group.grace_period, 86_400);
+    assert_eq!(group.penalty_rate, 5);
+    assert_eq!(group.contribution_amount, 10_000_000);
+    assert_eq!(group.max_members, 12);
+}
+
+#[test]
+fn test_create_group_from_weekly_savings_template() {
+    let (_env, client, creator, token) = setup();
+    let group_id = client.create_group_from_template(
+        &creator,
+        &token,
+        &GroupTemplate::WeeklySavings,
+        &1_000_000,
+        &5,
+    );
+    let group = client.get_group(&group_id);
+    assert_eq!(group.cycle_duration, 604_800);
+    assert_eq!(group.grace_period, 43_200);
+    assert_eq!(group.penalty_rate, 10);
+}
+
+#[test]
+fn test_create_group_from_emergency_fund_template() {
+    let (_env, client, creator, token) = setup();
+    let group_id = client.create_group_from_template(
+        &creator,
+        &token,
+        &GroupTemplate::EmergencyFund,
+        &50_000_000,
+        &8,
+    );
+    let group = client.get_group(&group_id);
+    assert_eq!(group.cycle_duration, 1_209_600);
+    assert_eq!(group.grace_period, 172_800);
+    assert_eq!(group.penalty_rate, 3);
+}
+
+#[test]
+fn test_create_group_from_investment_club_template() {
+    let (_env, client, creator, token) = setup();
+    let group_id = client.create_group_from_template(
+        &creator,
+        &token,
+        &GroupTemplate::InvestmentClub,
+        &100_000_000,
+        &10,
+    );
+    let group = client.get_group(&group_id);
+    assert_eq!(group.cycle_duration, 7_776_000);
+    assert_eq!(group.grace_period, 604_800);
+    assert_eq!(group.penalty_rate, 2);
+}
+
+#[test]
+fn test_create_group_from_custom_template() {
+    let (_env, client, creator, token) = setup();
+    // Custom template min is 1_000_000
+    let group_id = client.create_group_from_template(
+        &creator,
+        &token,
+        &GroupTemplate::Custom,
+        &5_000_000,
+        &20,
+    );
+    let group = client.get_group(&group_id);
+    assert_eq!(group.contribution_amount, 5_000_000);
+    assert_eq!(group.max_members, 20);
+}
+
+// ── parameter validation ──────────────────────────────────────────────────
+
+#[test]
+fn test_contribution_below_template_minimum_is_rejected() {
+    let (_env, client, creator, token) = setup();
+    // MonthlySavings min is 10_000_000; pass 1 stroop
+    let result = client.try_create_group_from_template(
+        &creator,
+        &token,
+        &GroupTemplate::MonthlySavings,
+        &1,
+        &5,
+    );
+    assert_eq!(result, Err(Ok(AjoError::ContributionAmountZero)));
+}
+
+#[test]
+fn test_max_members_below_minimum_rejected_via_template() {
+    let (_env, client, creator, token) = setup();
+    let result = client.try_create_group_from_template(
+        &creator,
+        &token,
+        &GroupTemplate::WeeklySavings,
+        &1_000_000,
+        &1, // below minimum of 2
+    );
+    assert_eq!(result, Err(Ok(AjoError::MaxMembersBelowMinimum)));
+}
+
+#[test]
+fn test_max_members_above_limit_rejected_via_template() {
+    let (_env, client, creator, token) = setup();
+    let result = client.try_create_group_from_template(
+        &creator,
+        &token,
+        &GroupTemplate::Custom,
+        &1_000_000,
+        &101, // above hard limit of 100
+    );
+    assert_eq!(result, Err(Ok(AjoError::MaxMembersAboveLimit)));
+}
+
+// ── suggested ranges ──────────────────────────────────────────────────────
+
+#[test]
+fn test_suggested_ranges_are_sensible() {
+    let (_env, client, _, _) = setup();
+    for template in [
+        GroupTemplate::MonthlySavings,
+        GroupTemplate::WeeklySavings,
+        GroupTemplate::EmergencyFund,
+        GroupTemplate::InvestmentClub,
+        GroupTemplate::Custom,
+    ] {
+        let cfg = client.get_template_config(&template);
+        assert!(cfg.suggested_contribution_min > 0);
+        assert!(cfg.suggested_contribution_max >= cfg.suggested_contribution_min);
+        assert!(cfg.suggested_max_members >= 2);
+        assert!(cfg.default_cycle_duration > 0);
+        assert!(cfg.default_penalty_rate <= 100);
+    }
+}


### PR DESCRIPTION
closes #341

Introduce GroupTemplate enum and TemplateConfig struct to simplify group
creation with sensible pre-configured defaults.

Templates:
- MonthlySavings: 30-day cycles, 1-day grace, 5% penalty, up to 12 members
- WeeklySavings:  7-day cycles, 12-hr grace, 10% penalty, up to 10 members
- EmergencyFund:  14-day cycles, 2-day grace, 3% penalty, up to 8 members
- InvestmentClub: 90-day cycles, 7-day grace, 2% penalty, up to 20 members
- Custom:         Fully flexible with minimal constraints

New contract functions:
- create_group_from_template: creates a group using template defaults while
  allowing contribution amount and member cap to be customised
- get_template_config: view function to inspect template defaults before creation
- list_available_templates: returns all available template variants

Contribution amounts below a template's suggested minimum are rejected.
All existing group parameter validation (max members, cycle duration, etc.)
continues to apply. Templates do not restrict custom group creation.
