### PR TITLE
Feature/audit i18n cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.6",
         "tsx": "^4.7.0",
-        "typescript": "^5.9.3"
+        "typescript": "^5.2.2"
       },
       "optionalDependencies": {
         "@esbuild/linux-x64": "^0.27.4"
@@ -719,6 +719,20 @@
       },
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
+    "backend/node_modules/typescript": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "frontend": {
@@ -34544,8 +34558,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
closes #592 
closes #593 
closes #594 


feat: backup recovery, audit logging, i18n API, and Redis caching (#384)                                            
                                                                                                                      
  ## Backup & Recovery System                                                                                         
  - Add `BackupRecord` Prisma model (type, status, storagePath, checksum,                                             
    encryptionKey ref, sizeBytes, metadata, timestamps)                                                               
  - Add `BackupService` with:                                                                                         
    - `triggerFullBackup()` — async pg_basebackup, non-blocking                                                       
    - `archiveWalSegment()` — WAL file copy + checksum recording                                                      
    - `verifyBackup()` — SHA-256 re-computation and comparison                                                        
    - `purgeOldBackups()` — retention-based record deletion                                                           
    - `getLatestFullBackup()` / `listBackups()` — query helpers                                                       
  - Add `/api/backups` routes: list, latest, trigger, verify, purge                                                   
  - Register daily full backup cron (02:30 UTC) and weekly purge (Sun 03:00 UTC)                                      
  - Add shell scripts:                                                                                                
    - `backup-base.sh` — pg_basebackup + SHA-256 checksum manifest + metadata JSON                                    
    - `restore-pitr.sh` — base extraction, recovery.signal, postgresql.auto.conf                                      
      with restore_command and optional recovery_target_time                                                          
    - `verify-restore.sh` — connectivity, recovery mode, table existence, WAL position                                
                                                                                                                      
  ## Audit Logging System                                                                                             
  - Add `AuditLog` Prisma model with indexes on actor, action, target, timestamp                                      
  - Rewrite `auditService.ts` with:                                                                                   
    - `auditLog()` — write entry (backward-compatible with legacy adminId shape)                                      
    - `searchAuditLogs()` — paginated, filterable by actor/action/target/date range                                   
    - `generateComplianceReport()` — top actions, top actors, target breakdown                                        
    - `purgeAuditLogs()` — delete records older than retention window (default 90d)                                   
  - Add `/api/audit` routes:                                                                                          
    - `GET /api/audit` — search with query params                                                                     
    - `GET /api/audit/report` — compliance report for date range                                                      
    - `POST /api/audit/purge` — purge old records                                                                     
                                                                                                                      
  ## i18n API                                                                                                         
  - Add `i18nService.ts` with:                                                                                        
    - `SUPPORTED_LANGUAGES` — 6 locales (en, es, fr, sw, pt, ar) with RTL flag                                        
    - `detectLanguage()` — parses Accept-Language header with q-value priority                                        
    - `getTranslations()` — loads and caches locale JSON files                                                        
    - `translateKey()` — dot-notation key lookup (e.g. `common.loading`)                                              
    - `clearTranslationCache()` — invalidate in-memory cache                                                          
  - Add `/api/i18n` routes:                                                                                           
    - `GET /api/i18n/languages` — list all supported languages with RTL flag                                          
    - `GET /api/i18n/detect` — detect language from request header                                                    
    - `GET /api/i18n/:locale` — full translation messages for a locale                                                
    - `GET /api/i18n/:locale/key/*` — single key translation                                                          
  - Add `frontend/src/locales/ar.json` — full Arabic translation (217 keys)                                           
  - Update `frontend/src/i18n.ts` — add 'ar' to locales array, export `isRtl()`                                       
                                                                                                                      
  ## Redis Caching Layer                                                                                              
  - Rewrite `cacheService.ts` with:                                                                                   
    - `CacheKeys` namespace — typed key generators (group, allGroups, metrics)                                        
    - `invalidatePattern()` — non-blocking SCAN-based bulk invalidation                                               
    - `invalidateGroup()` — invalidates group + metrics + allGroups keys                                              
    - `warmCache()` — pre-populates Redis with all active groups on startup                                           
    - `getRedisMetrics()` — hit rate, memory usage, connected clients, uptime                                         
    - Cache-aside pattern on `getGroupWithCache()` and `getAllGroupsFast()`                                           
    - Auto-invalidation on `recordContribution()`                                                                     
  - Add `/api/cache` routes:                                                                                          
    - `GET /api/cache/stats` — Redis performance metrics and hit rate                                                 
    - `POST /api/cache/warm` — trigger cache warming                                                                  
    - `DELETE /api/cache/key/:key` — delete specific key                                                              
    - `DELETE /api/cache/pattern` — bulk invalidate by glob pattern                                                   
                                                                                                                      
  ## Infrastructure                                                                                                   
  - All new routes registered in `backend/src/index.ts`                                                               
  - All routes protected by `authMiddleware` (except public i18n endpoints)                                           
  - Zero TypeScript errors introduced in new files    