### PR TITLE
feat: add offline mode with local storage, sync, and conflict resolution

### DIFF
--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { AuthProvider } from '@/context/AuthContext'
 import { ThemeProvider } from '@/context/ThemeContext'
+import { OfflineProvider } from '@/context/OfflineContext'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useState, useEffect } from 'react'
 import { Toaster } from 'react-hot-toast'
@@ -51,9 +52,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
         <AuthProvider>
-          <OnboardingInitializer />
-          {children}
-          <Toaster position="top-right" />
+          <OfflineProvider>
+            <OnboardingInitializer />
+            {children}
+            <Toaster position="top-right" />
+          </OfflineProvider>
         </AuthProvider>
       </ThemeProvider>
     </QueryClientProvider>

--- a/frontend/src/components/OfflineIndicator.tsx
+++ b/frontend/src/components/OfflineIndicator.tsx
@@ -1,71 +1,71 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { WifiOff, Wifi, Clock } from 'lucide-react'
-import { getPendingActionCount } from '../utils/syncManager'
+import { WifiOff, Wifi, RefreshCw } from 'lucide-react'
+import { useOfflineContext } from '@/context/OfflineContext'
 
 export function OfflineIndicator() {
-  const [isOnline, setIsOnline] = useState(true)
-  const [showNotification, setShowNotification] = useState(false)
-  const [pendingCount, setPendingCount] = useState(0)
+  const { isOnline, isSyncing, pendingCount } = useOfflineContext()
+  const [visible, setVisible] = useState(false)
+  const [justCameOnline, setJustCameOnline] = useState(false)
 
   useEffect(() => {
-    setIsOnline(navigator.onLine)
-    updatePendingCount()
-
-    const handleOnline = async () => {
-      setIsOnline(true)
-      setShowNotification(true)
-      await updatePendingCount()
-      setTimeout(() => setShowNotification(false), 3000)
+    if (!isOnline) {
+      setVisible(true)
+      setJustCameOnline(false)
+    } else if (isSyncing) {
+      setVisible(true)
+      setJustCameOnline(false)
+    } else if (justCameOnline) {
+      setVisible(true)
+      const t = setTimeout(() => setVisible(false), 3000)
+      return () => clearTimeout(t)
     }
+  }, [isOnline, isSyncing, justCameOnline])
 
-    const handleOffline = () => {
-      setIsOnline(false)
-      setShowNotification(true)
+  // Track transition from offline → online
+  useEffect(() => {
+    if (isOnline && !isSyncing) {
+      setJustCameOnline(true)
     }
+  }, [isOnline, isSyncing])
 
-    window.addEventListener('online', handleOnline)
-    window.addEventListener('offline', handleOffline)
+  if (!visible) return null
 
-    return () => {
-      window.removeEventListener('online', handleOnline)
-      window.removeEventListener('offline', handleOffline)
-    }
-  }, [])
-
-  const updatePendingCount = async () => {
-    const count = await getPendingActionCount()
-    setPendingCount(count)
-  }
-
-  if (!showNotification && isOnline) return null
+  const isSyncingState = isSyncing && isOnline
+  const isBackOnline = isOnline && !isSyncing && justCameOnline
 
   return (
     <div
-      className={`fixed top-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg flex items-center gap-2 animate-slide-down ${
-        isOnline
+      role="status"
+      aria-live="polite"
+      className={`fixed top-4 right-4 z-50 px-4 py-3 rounded-lg shadow-lg flex items-center gap-2 transition-all animate-slide-down ${
+        isSyncingState
+          ? 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-100'
+          : isBackOnline
           ? 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-100'
           : 'bg-orange-100 dark:bg-orange-900 text-orange-800 dark:text-orange-100'
       }`}
     >
-      {isOnline ? (
+      {isSyncingState ? (
         <>
-          <Wifi className="w-5 h-5" />
-          <span className="font-medium">Back online</span>
+          <RefreshCw className="w-5 h-5 animate-spin" aria-hidden="true" />
+          <span className="font-medium">Syncing</span>
           {pendingCount > 0 && (
-            <span className="text-sm">({pendingCount} actions synced)</span>
+            <span className="text-sm">({pendingCount} pending)</span>
           )}
+        </>
+      ) : isBackOnline ? (
+        <>
+          <Wifi className="w-5 h-5" aria-hidden="true" />
+          <span className="font-medium">Back online</span>
         </>
       ) : (
         <>
-          <WifiOff className="w-5 h-5" />
+          <WifiOff className="w-5 h-5" aria-hidden="true" />
           <span className="font-medium">You're offline</span>
           {pendingCount > 0 && (
-            <div className="flex items-center gap-1 ml-2">
-              <Clock className="w-4 h-4" />
-              <span className="text-sm">{pendingCount} pending</span>
-            </div>
+            <span className="text-sm ml-1">· {pendingCount} pending</span>
           )}
         </>
       )}

--- a/frontend/src/context/OfflineContext.tsx
+++ b/frontend/src/context/OfflineContext.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useRef, useState, useCallback } from 'react';
+import { offlineStorage } from '@/utils/offlineStorage';
+import { syncPendingActions, queueAction, getPendingActionCount } from '@/utils/syncManager';
+import type { Group } from '@/types';
+
+interface Action {
+  id: string;
+  type: string;
+  payload: any;
+  timestamp: number;
+}
+
+interface OfflineContextValue {
+  isOnline: boolean;
+  isSyncing: boolean;
+  pendingCount: number;
+  cachedGroups: Group[];
+  cachedDashboard: Record<string, unknown> | null;
+  addPendingAction: (action: Omit<Action, 'id' | 'timestamp'>) => Promise<void>;
+  refreshCache: () => Promise<void>;
+}
+
+const OfflineContext = createContext<OfflineContextValue | null>(null);
+
+export function OfflineProvider({ children }: { children: React.ReactNode }) {
+  const [isOnline, setIsOnline] = useState(
+    typeof navigator !== 'undefined' ? navigator.onLine : true,
+  );
+  const [isSyncing, setIsSyncing] = useState(false);
+  const [pendingCount, setPendingCount] = useState(0);
+  const [cachedGroups, setCachedGroups] = useState<Group[]>([]);
+  const [cachedDashboard, setCachedDashboard] = useState<Record<string, unknown> | null>(null);
+  const wasOffline = useRef(false);
+
+  const refreshCache = useCallback(async () => {
+    const [groups, dashboard] = await Promise.all([
+      offlineStorage.getCachedGroups(),
+      offlineStorage.getCachedDashboard(),
+    ]);
+    setCachedGroups(groups);
+    setCachedDashboard(dashboard);
+    const count = await getPendingActionCount();
+    setPendingCount(count);
+  }, []);
+
+  // Load cache on mount
+  useEffect(() => {
+    refreshCache();
+  }, [refreshCache]);
+
+  useEffect(() => {
+    const handleOnline = async () => {
+      setIsOnline(true);
+      if (wasOffline.current) {
+        wasOffline.current = false;
+        setIsSyncing(true);
+        try {
+          await syncPendingActions();
+        } finally {
+          setIsSyncing(false);
+          await refreshCache();
+        }
+      }
+    };
+
+    const handleOffline = () => {
+      setIsOnline(false);
+      wasOffline.current = true;
+    };
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, [refreshCache]);
+
+  const addPendingAction = useCallback(
+    async (action: Omit<Action, 'id' | 'timestamp'>) => {
+      const full: Action = {
+        ...action,
+        id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        timestamp: Date.now(),
+      };
+      await queueAction(full);
+      setPendingCount((c) => c + 1);
+    },
+    [],
+  );
+
+  return (
+    <OfflineContext.Provider
+      value={{
+        isOnline,
+        isSyncing,
+        pendingCount,
+        cachedGroups,
+        cachedDashboard,
+        addPendingAction,
+        refreshCache,
+      }}
+    >
+      {children}
+    </OfflineContext.Provider>
+  );
+}
+
+export function useOfflineContext(): OfflineContextValue {
+  const ctx = useContext(OfflineContext);
+  if (!ctx) throw new Error('useOfflineContext must be used within OfflineProvider');
+  return ctx;
+}

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -2,6 +2,9 @@
  * Central entry point for all custom React hooks.
  * Exports hooks for state management, blockchain interaction, and UI utilities.
  */
+export { useOfflineMode } from './useOfflineMode'
+export type { UseOfflineModeReturn } from './useOfflineMode'
+export { useOfflineContext, OfflineProvider } from '@/context/OfflineContext'
 export { useTableState } from './useTableState'
 export type { TableFilters, UseTableStateOptions, UseTableStateReturn } from './useTableState'
 export { useSkeletonDelay } from './useSkeletonDelay'

--- a/frontend/src/hooks/useOfflineMode.ts
+++ b/frontend/src/hooks/useOfflineMode.ts
@@ -1,50 +1,43 @@
-import { useState, useEffect } from 'react';
-import { queueAction, syncPendingActions } from '../utils/syncManager';
+import { useOfflineContext } from '@/context/OfflineContext';
+import type { Group } from '@/types';
 
 interface Action {
-  id: string;
   type: string;
   payload: any;
-  timestamp: number;
 }
 
-export function useOfflineMode() {
-  const [isOnline, setIsOnline] = useState(navigator.onLine);
-  const [pendingActions, setPendingActions] = useState<Action[]>([]);
+export interface UseOfflineModeReturn {
+  isOnline: boolean;
+  isSyncing: boolean;
+  pendingCount: number;
+  cachedGroups: Group[];
+  cachedDashboard: Record<string, unknown> | null;
+  queueAction: (action: Action) => Promise<void>;
+  refreshCache: () => Promise<void>;
+}
 
-  useEffect(() => {
-    const handleOnline = async () => {
-      setIsOnline(true);
-      await syncPendingActions();
-      // Refresh pending actions list
-      setPendingActions([]);
-    };
+/**
+ * Convenience hook for offline mode state and actions.
+ * Delegates to OfflineContext — must be used inside OfflineProvider.
+ */
+export function useOfflineMode(): UseOfflineModeReturn {
+  const {
+    isOnline,
+    isSyncing,
+    pendingCount,
+    cachedGroups,
+    cachedDashboard,
+    addPendingAction,
+    refreshCache,
+  } = useOfflineContext();
 
-    const handleOffline = () => {
-      setIsOnline(false);
-    };
-
-    window.addEventListener('online', handleOnline);
-    window.addEventListener('offline', handleOffline);
-
-    return () => {
-      window.removeEventListener('online', handleOnline);
-      window.removeEventListener('offline', handleOffline);
-    };
-  }, []);
-
-  const addPendingAction = (action: Omit<Action, 'id' | 'timestamp'>) => {
-    const fullAction: Action = {
-      ...action,
-      id: Date.now().toString(),
-      timestamp: Date.now(),
-    };
-
-    if (!isOnline) {
-      queueAction(fullAction);
-      setPendingActions(prev => [...prev, fullAction]);
-    }
+  return {
+    isOnline,
+    isSyncing,
+    pendingCount,
+    cachedGroups,
+    cachedDashboard,
+    queueAction: addPendingAction,
+    refreshCache,
   };
-
-  return { isOnline, pendingActions, queueAction: addPendingAction };
 }

--- a/frontend/src/utils/offlineStorage.ts
+++ b/frontend/src/utils/offlineStorage.ts
@@ -1,5 +1,7 @@
 // Offline storage utilities using IndexedDB
 
+import type { Group } from '@/types'
+
 interface Action {
   id: string;
   type: string;
@@ -7,14 +9,23 @@ interface Action {
   timestamp: number;
 }
 
+export interface CachedData {
+  groups?: Group[];
+  dashboardStats?: Record<string, unknown>;
+  cachedAt: number;
+}
+
 class OfflineStorage {
   private db: IDBDatabase | null = null;
   private readonly dbName = 'AjoOfflineDB';
-  private readonly storeName = 'pendingActions';
+  private readonly version = 2;
+  private readonly actionsStore = 'pendingActions';
+  private readonly cacheStore = 'dataCache';
 
   async init(): Promise<void> {
+    if (this.db) return;
     return new Promise((resolve, reject) => {
-      const request = indexedDB.open(this.dbName, 1);
+      const request = indexedDB.open(this.dbName, this.version);
 
       request.onerror = () => reject(request.error);
       request.onsuccess = () => {
@@ -24,63 +35,108 @@ class OfflineStorage {
 
       request.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result;
-        if (!db.objectStoreNames.contains(this.storeName)) {
-          db.createObjectStore(this.storeName, { keyPath: 'id' });
+        if (!db.objectStoreNames.contains(this.actionsStore)) {
+          db.createObjectStore(this.actionsStore, { keyPath: 'id' });
+        }
+        if (!db.objectStoreNames.contains(this.cacheStore)) {
+          db.createObjectStore(this.cacheStore, { keyPath: 'key' });
         }
       };
     });
   }
 
+  // ── Pending Actions ──────────────────────────────────────────────────────────
+
   async addAction(action: Action): Promise<void> {
-    if (!this.db) await this.init();
-
+    await this.init();
     return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction([this.storeName], 'readwrite');
-      const store = transaction.objectStore(this.storeName);
-      const request = store.add(action);
-
-      request.onerror = () => reject(request.error);
-      request.onsuccess = () => resolve();
+      const tx = this.db!.transaction([this.actionsStore], 'readwrite');
+      const req = tx.objectStore(this.actionsStore).add(action);
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => resolve();
     });
   }
 
   async getAllActions(): Promise<Action[]> {
-    if (!this.db) await this.init();
-
+    await this.init();
     return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction([this.storeName], 'readonly');
-      const store = transaction.objectStore(this.storeName);
-      const request = store.getAll();
-
-      request.onerror = () => reject(request.error);
-      request.onsuccess = () => resolve(request.result);
+      const tx = this.db!.transaction([this.actionsStore], 'readonly');
+      const req = tx.objectStore(this.actionsStore).getAll();
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => resolve(req.result);
     });
   }
 
   async removeAction(id: string): Promise<void> {
-    if (!this.db) await this.init();
-
+    await this.init();
     return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction([this.storeName], 'readwrite');
-      const store = transaction.objectStore(this.storeName);
-      const request = store.delete(id);
-
-      request.onerror = () => reject(request.error);
-      request.onsuccess = () => resolve();
+      const tx = this.db!.transaction([this.actionsStore], 'readwrite');
+      const req = tx.objectStore(this.actionsStore).delete(id);
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => resolve();
     });
   }
 
   async clearAll(): Promise<void> {
-    if (!this.db) await this.init();
-
+    await this.init();
     return new Promise((resolve, reject) => {
-      const transaction = this.db!.transaction([this.storeName], 'readwrite');
-      const store = transaction.objectStore(this.storeName);
-      const request = store.clear();
-
-      request.onerror = () => reject(request.error);
-      request.onsuccess = () => resolve();
+      const tx = this.db!.transaction([this.actionsStore], 'readwrite');
+      const req = tx.objectStore(this.actionsStore).clear();
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => resolve();
     });
+  }
+
+  // ── Data Cache ───────────────────────────────────────────────────────────────
+
+  async setCacheEntry<T>(key: string, data: T): Promise<void> {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      const tx = this.db!.transaction([this.cacheStore], 'readwrite');
+      const req = tx.objectStore(this.cacheStore).put({ key, data, cachedAt: Date.now() });
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => resolve();
+    });
+  }
+
+  async getCacheEntry<T>(key: string): Promise<{ data: T; cachedAt: number } | null> {
+    await this.init();
+    return new Promise((resolve, reject) => {
+      const tx = this.db!.transaction([this.cacheStore], 'readonly');
+      const req = tx.objectStore(this.cacheStore).get(key);
+      req.onerror = () => reject(req.error);
+      req.onsuccess = () => resolve(req.result ?? null);
+    });
+  }
+
+  /** Merge incoming groups with cached groups using last-write-wins on createdAt. */
+  async mergeGroups(incoming: Group[]): Promise<Group[]> {
+    const cached = await this.getCacheEntry<Group[]>('groups');
+    const existing = cached?.data ?? [];
+    const map = new Map<string, Group>(existing.map((g) => [g.id, g]));
+    for (const group of incoming) {
+      const prev = map.get(group.id);
+      if (!prev || group.createdAt >= prev.createdAt) {
+        map.set(group.id, group);
+      }
+    }
+    const merged = Array.from(map.values());
+    await this.setCacheEntry('groups', merged);
+    return merged;
+  }
+
+  async getCachedGroups(): Promise<Group[]> {
+    const entry = await this.getCacheEntry<Group[]>('groups');
+    return entry?.data ?? [];
+  }
+
+  async setCachedDashboard(stats: Record<string, unknown>): Promise<void> {
+    await this.setCacheEntry('dashboardStats', stats);
+  }
+
+  async getCachedDashboard(): Promise<Record<string, unknown> | null> {
+    const entry = await this.getCacheEntry<Record<string, unknown>>('dashboardStats');
+    return entry?.data ?? null;
   }
 }
 

--- a/frontend/src/utils/syncManager.ts
+++ b/frontend/src/utils/syncManager.ts
@@ -1,4 +1,5 @@
 import { offlineStorage } from './offlineStorage';
+import { backendApiClient } from '@/lib/apiClient';
 
 interface Action {
   id: string;
@@ -16,45 +17,77 @@ export async function queueAction(action: Action): Promise<void> {
 }
 
 export async function syncPendingActions(): Promise<void> {
-  try {
-    const pendingActions = await offlineStorage.getAllActions();
+  const pendingActions = await offlineStorage.getAllActions();
 
-    for (const action of pendingActions) {
-      try {
-        // Attempt to sync the action
-        await syncAction(action);
-        // Remove from storage if successful
-        await offlineStorage.removeAction(action.id);
-      } catch (error) {
-        console.error(`Failed to sync action ${action.id}:`, error);
-        // Keep the action in storage for retry
-      }
+  for (const action of pendingActions) {
+    try {
+      await syncAction(action);
+      await offlineStorage.removeAction(action.id);
+    } catch (error) {
+      console.error(`Failed to sync action ${action.id}:`, error);
+      // Keep in storage for retry on next sync
     }
-  } catch (error) {
-    console.error('Failed to sync pending actions:', error);
+  }
+
+  // Refresh data cache after sync
+  try {
+    const groups = await backendApiClient.request<any[]>({ path: '/api/v1/groups', method: 'GET' });
+    if (Array.isArray(groups)) {
+      await offlineStorage.mergeGroups(groups);
+    }
+  } catch {
+    // Network still flaky — cached data remains valid
   }
 }
 
+/**
+ * Execute a single queued action against the real API.
+ * Uses last-write-wins: the server is authoritative on success.
+ */
 async function syncAction(action: Action): Promise<void> {
-  // This would integrate with your API service
-  // For now, we'll simulate a sync
-  console.log('Syncing action:', action);
+  switch (action.type) {
+    case 'createGroup':
+      await backendApiClient.request({
+        path: '/api/v1/groups',
+        method: 'POST',
+        body: action.payload,
+      });
+      break;
 
-  // Simulate API call
-  await new Promise(resolve => setTimeout(resolve, 100));
+    case 'joinGroup':
+      await backendApiClient.request({
+        path: `/api/v1/groups/${action.payload.groupId}/join`,
+        method: 'POST',
+        body: { publicKey: action.payload.publicKey },
+      });
+      break;
 
-  // In a real implementation, you would:
-  // - Make the actual API request based on action.type
-  // - Handle success/failure appropriately
-  // - Update local state optimistically
+    case 'contribute':
+      await backendApiClient.request({
+        path: `/api/v1/groups/${action.payload.groupId}/contribute`,
+        method: 'POST',
+        body: {
+          amount: action.payload.amount,
+          signedXdr: action.payload.signedXdr,
+        },
+      });
+      break;
+
+    default:
+      // Generic fallback: POST to /api/v1/actions with the full action payload
+      await backendApiClient.request({
+        path: '/api/v1/actions',
+        method: 'POST',
+        body: action,
+      });
+  }
 }
 
 export async function getPendingActionCount(): Promise<number> {
   try {
     const actions = await offlineStorage.getAllActions();
     return actions.length;
-  } catch (error) {
-    console.error('Failed to get pending action count:', error);
+  } catch {
     return 0;
   }
 }


### PR DESCRIPTION
closes #607 

- Extend IndexedDB (v2) with dataCache store for groups/dashboard
- Implement real API sync in syncManager with last-write-wins conflict resolution
- Add OfflineContext provider (isOnline, isSyncing, pendingCount, cachedGroups)
- Upgrade useOfflineMode hook to delegate to OfflineContext
- Upgrade OfflineIndicator with offline/syncing/back-online states
- Wire OfflineProvider into app providers
- #closes #607