### PR TITLE
feat: build notification center UI (#604)

### DIFF
--- a/frontend/src/app/[locale]/notifications/page.tsx
+++ b/frontend/src/app/[locale]/notifications/page.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from 'next';
 import NotificationCenter from '@/components/NotificationCenter';
+
+export const metadata: Metadata = {
+  title: 'Notifications | Ajo',
+  description: 'View and manage your notifications',
+};
 
 export default function NotificationsPage() {
   return <NotificationCenter />;

--- a/frontend/src/app/invitations/page.tsx
+++ b/frontend/src/app/invitations/page.tsx
@@ -83,6 +83,7 @@ export default function InvitationsPage() {
     addNotification({
       id: `notification-${invitation.id}`,
       type: 'group_invitation',
+      category: 'groups',
       title: 'Invitation sent',
       message: `Invitation sent to ${draft.recipientName || draft.recipientAddress} for ${draft.groupName}.`,
       timestamp: Date.now(),
@@ -106,6 +107,7 @@ export default function InvitationsPage() {
     addNotification({
       id: `notification-${id}-${status}`,
       type: 'invitation_response',
+      category: 'members',
       title: status === 'accepted' ? 'Invitation accepted' : 'Invitation declined',
       message: createNotificationMessage(invitation, status),
       timestamp: Date.now(),
@@ -126,6 +128,7 @@ export default function InvitationsPage() {
     addNotification({
       id: `notification-${id}-revoked`,
       type: 'group_invitation',
+      category: 'groups',
       title: 'Invitation revoked',
       message: `Invitation for ${invitation.groupName} was revoked before the recipient responded.`,
       timestamp: Date.now(),

--- a/frontend/src/components/NotificationCenter.tsx
+++ b/frontend/src/components/NotificationCenter.tsx
@@ -1,11 +1,24 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
-import { Bell, Trash2, CheckCheck, Wifi, WifiOff, RefreshCw } from 'lucide-react'
-import { useNotifications } from '@/hooks/useNotifications'
+import React, { useState, useMemo } from 'react'
+import {
+  Bell, Trash2, CheckCheck, Wifi, WifiOff, RefreshCw, Filter, Search,
+} from 'lucide-react'
+import { useNotifications, type NotificationCategory } from '@/hooks/useNotifications'
 import { useWebSocket } from '@/hooks/useWebSocket'
 import { NoNotifications } from './empty/NoNotifications'
 import NotificationItem from './NotificationItem'
+
+type ReadFilter = 'all' | 'unread' | 'read'
+
+const CATEGORIES: { value: NotificationCategory | 'all'; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'contributions', label: 'Contributions' },
+  { value: 'payouts', label: 'Payouts' },
+  { value: 'members', label: 'Members' },
+  { value: 'groups', label: 'Groups' },
+  { value: 'system', label: 'System' },
+]
 
 export default function NotificationCenter() {
   const {
@@ -19,22 +32,17 @@ export default function NotificationCenter() {
     requestBrowserPermission,
   } = useNotifications()
 
-  const [filter, setFilter] = useState<'all' | 'unread'>('all')
-  const [permissionStatus, setPermissionStatus] = useState<NotificationPermission>('default')
-
-  // Wire up real-time WebSocket
-  const { status: wsStatus, isConnected, markRead } = useWebSocket({
-    onNotification: (payload) => {
-      addNotification(payload)
-    },
+  const [activeCategory, setActiveCategory] = useState<NotificationCategory | 'all'>('all')
+  const [readFilter, setReadFilter] = useState<ReadFilter>('all')
+  const [search, setSearch] = useState('')
+  const [permissionStatus, setPermissionStatus] = useState<NotificationPermission>(() => {
+    if (typeof window !== 'undefined' && 'Notification' in window) return Notification.permission
+    return 'default'
   })
 
-  // Sync browser permission state
-  useEffect(() => {
-    if (typeof window !== 'undefined' && 'Notification' in window) {
-      setPermissionStatus(Notification.permission)
-    }
-  }, [])
+  const { status: wsStatus, isConnected, markRead } = useWebSocket({
+    onNotification: (payload) => addNotification(payload),
+  })
 
   const handleRequestPermission = async () => {
     const result = await requestBrowserPermission()
@@ -46,35 +54,55 @@ export default function NotificationCenter() {
     markRead(id)
   }
 
-  const filteredNotifications =
-    filter === 'unread' ? notifications.filter((n) => !n.read) : notifications
+  const filtered = useMemo(() => {
+    let list = notifications
+
+    if (activeCategory !== 'all') {
+      list = list.filter((n) => n.category === activeCategory)
+    }
+    if (readFilter === 'unread') list = list.filter((n) => !n.read)
+    if (readFilter === 'read') list = list.filter((n) => n.read)
+    if (search.trim()) {
+      const q = search.toLowerCase()
+      list = list.filter(
+        (n) =>
+          n.title.toLowerCase().includes(q) ||
+          n.message.toLowerCase().includes(q)
+      )
+    }
+
+    return list
+  }, [notifications, activeCategory, readFilter, search])
 
   const unreadCount = getUnreadCount()
 
-  const wsStatusLabel: Record<typeof wsStatus, string> = {
+  const categoryUnread = (cat: NotificationCategory | 'all') =>
+    cat === 'all'
+      ? unreadCount
+      : notifications.filter((n) => n.category === cat && !n.read).length
+
+  const wsLabel: Record<typeof wsStatus, string> = {
     connected: 'Live',
     connecting: 'Connecting…',
     disconnected: 'Offline',
-    error: 'Connection error',
+    error: 'Error',
   }
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Header */}
-        <div className="mb-6 flex items-start justify-between">
+
+        {/* ── Header ── */}
+        <div className="mb-6 flex items-start justify-between gap-4">
           <div>
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-1">
-              Notifications
-            </h1>
-            <p className="text-gray-600 dark:text-gray-400">
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Notifications</h1>
+            <p className="text-gray-500 dark:text-gray-400 mt-1 text-sm">
               Stay updated with your savings groups
             </p>
           </div>
 
-          {/* WebSocket status badge */}
           <div
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium ${
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium shrink-0 ${
               isConnected
                 ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
                 : wsStatus === 'connecting'
@@ -89,16 +117,16 @@ export default function NotificationCenter() {
             ) : (
               <WifiOff className="w-3 h-3" />
             )}
-            {wsStatusLabel[wsStatus]}
+            {wsLabel[wsStatus]}
           </div>
         </div>
 
-        {/* Browser notification permission banner */}
+        {/* ── Browser permission banner ── */}
         {permissionStatus === 'default' && (
           <div className="mb-4 flex items-center justify-between bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-xl px-4 py-3">
             <div className="flex items-center gap-2 text-sm text-blue-700 dark:text-blue-300">
               <Bell className="w-4 h-4 shrink-0" />
-              Enable browser notifications to get alerts even when the tab is in the background.
+              Enable browser notifications to get alerts in the background.
             </div>
             <button
               onClick={handleRequestPermission}
@@ -109,46 +137,83 @@ export default function NotificationCenter() {
           </div>
         )}
 
-        {/* Actions Bar */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4 mb-6">
-          <div className="flex flex-wrap items-center justify-between gap-4">
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => setFilter('all')}
-                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  filter === 'all'
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-                }`}
-              >
-                All ({notifications.length})
-              </button>
-              <button
-                onClick={() => setFilter('unread')}
-                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  filter === 'unread'
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-                }`}
-              >
-                Unread ({unreadCount})
-              </button>
+        {/* ── Category tabs ── */}
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 mb-4 overflow-x-auto">
+          <div className="flex min-w-max">
+            {CATEGORIES.map(({ value, label }) => {
+              const count = categoryUnread(value)
+              const active = activeCategory === value
+              return (
+                <button
+                  key={value}
+                  onClick={() => setActiveCategory(value)}
+                  className={`flex items-center gap-1.5 px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+                    active
+                      ? 'border-blue-600 text-blue-600 dark:text-blue-400 dark:border-blue-400'
+                      : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:border-gray-300'
+                  }`}
+                >
+                  {label}
+                  {count > 0 && (
+                    <span className={`inline-flex items-center justify-center w-5 h-5 rounded-full text-xs font-bold ${
+                      active ? 'bg-blue-600 text-white' : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300'
+                    }`}>
+                      {count > 9 ? '9+' : count}
+                    </span>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* ── Filters + search + actions ── */}
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-4 mb-4">
+          <div className="flex flex-wrap items-center gap-3">
+            {/* Search */}
+            <div className="relative flex-1 min-w-[180px]">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+              <input
+                type="search"
+                placeholder="Search notifications…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="w-full pl-9 pr-3 py-2 text-sm bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
             </div>
 
-            <div className="flex items-center gap-2">
+            {/* Read filter */}
+            <div className="flex items-center gap-1 bg-gray-100 dark:bg-gray-700 rounded-lg p-1">
+              {(['all', 'unread', 'read'] as ReadFilter[]).map((f) => (
+                <button
+                  key={f}
+                  onClick={() => setReadFilter(f)}
+                  className={`px-3 py-1.5 rounded-md text-xs font-medium capitalize transition-colors ${
+                    readFilter === f
+                      ? 'bg-white dark:bg-gray-600 text-gray-900 dark:text-white shadow-sm'
+                      : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
+                  }`}
+                >
+                  {f}
+                </button>
+              ))}
+            </div>
+
+            {/* Bulk actions */}
+            <div className="flex items-center gap-2 ml-auto">
               {unreadCount > 0 && (
                 <button
                   onClick={markAllAsRead}
-                  className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors"
+                  className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 rounded-lg transition-colors"
                 >
                   <CheckCheck className="w-4 h-4" />
-                  Mark all as read
+                  Mark all read
                 </button>
               )}
               {notifications.length > 0 && (
                 <button
                   onClick={clearAll}
-                  className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
+                  className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
                 >
                   <Trash2 className="w-4 h-4" />
                   Clear all
@@ -156,23 +221,31 @@ export default function NotificationCenter() {
               )}
             </div>
           </div>
+
+          {/* Result count */}
+          <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+            {filtered.length} notification{filtered.length !== 1 ? 's' : ''}
+            {readFilter !== 'all' || activeCategory !== 'all' || search ? ' (filtered)' : ''}
+          </p>
         </div>
 
-        {/* Notifications List */}
-        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
-          {filteredNotifications.length === 0 ? (
+        {/* ── Notification list ── */}
+        <div
+          className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden"
+          role="list"
+          aria-label="Notifications"
+        >
+          {filtered.length === 0 ? (
             <NoNotifications />
           ) : (
-            <div>
-              {filteredNotifications.map((notification) => (
-                <NotificationItem
-                  key={notification.id}
-                  notification={notification}
-                  onMarkAsRead={handleMarkAsRead}
-                  onDelete={deleteNotification}
-                />
-              ))}
-            </div>
+            filtered.map((notification) => (
+              <NotificationItem
+                key={notification.id}
+                notification={notification}
+                onMarkAsRead={handleMarkAsRead}
+                onDelete={deleteNotification}
+              />
+            ))
           )}
         </div>
       </div>

--- a/frontend/src/components/NotificationItem.tsx
+++ b/frontend/src/components/NotificationItem.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import React from 'react';
-import type { Notification } from '@/hooks/useNotifications';
+import type { Notification, NotificationCategory } from '@/hooks/useNotifications';
 import { formatDistanceToNow } from 'date-fns';
-import { X, Bell, DollarSign, Users, CheckCircle, Megaphone, AlertCircle } from 'lucide-react';
+import {
+  X, Bell, DollarSign, Users, CheckCircle, Megaphone, AlertCircle,
+  TrendingUp, Settings, UserPlus,
+} from 'lucide-react';
 
 interface NotificationItemProps {
   notification: Notification;
@@ -15,68 +18,97 @@ const iconMap: Record<Notification['type'], React.ElementType> = {
   contribution_due: Bell,
   contribution_overdue: AlertCircle,
   contribution_received: DollarSign,
-  payout_received: DollarSign,
-  member_joined: Users,
+  payout_received: TrendingUp,
+  member_joined: UserPlus,
   member_left: Users,
   cycle_completed: CheckCircle,
   group_created: CheckCircle,
   announcement: Megaphone,
+  group_invitation: UserPlus,
+  invitation_response: Users,
 };
 
-const colorMap: Record<Notification['type'], string> = {
+const typeColorMap: Record<Notification['type'], string> = {
   contribution_due: 'bg-blue-100 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400',
   contribution_overdue: 'bg-red-100 text-red-600 dark:bg-red-900/20 dark:text-red-400',
   contribution_received: 'bg-green-100 text-green-600 dark:bg-green-900/20 dark:text-green-400',
-  payout_received: 'bg-green-100 text-green-600 dark:bg-green-900/20 dark:text-green-400',
+  payout_received: 'bg-emerald-100 text-emerald-600 dark:bg-emerald-900/20 dark:text-emerald-400',
   member_joined: 'bg-purple-100 text-purple-600 dark:bg-purple-900/20 dark:text-purple-400',
   member_left: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
   cycle_completed: 'bg-teal-100 text-teal-600 dark:bg-teal-900/20 dark:text-teal-400',
   group_created: 'bg-teal-100 text-teal-600 dark:bg-teal-900/20 dark:text-teal-400',
   announcement: 'bg-orange-100 text-orange-600 dark:bg-orange-900/20 dark:text-orange-400',
+  group_invitation: 'bg-violet-100 text-violet-600 dark:bg-violet-900/20 dark:text-violet-400',
+  invitation_response: 'bg-indigo-100 text-indigo-600 dark:bg-indigo-900/20 dark:text-indigo-400',
 };
 
-export default function NotificationItem({
-  notification,
-  onMarkAsRead,
-  onDelete,
-}: NotificationItemProps) {
-  const Icon = iconMap[notification.type];
+const categoryConfig: Record<NotificationCategory, { label: string; className: string }> = {
+  contributions: { label: 'Contributions', className: 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300' },
+  payouts: { label: 'Payouts', className: 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300' },
+  members: { label: 'Members', className: 'bg-purple-50 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300' },
+  groups: { label: 'Groups', className: 'bg-teal-50 text-teal-700 dark:bg-teal-900/30 dark:text-teal-300' },
+  system: { label: 'System', className: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300' },
+};
+
+export default function NotificationItem({ notification, onMarkAsRead, onDelete }: NotificationItemProps) {
+  const Icon = iconMap[notification.type] ?? Bell;
+  const cat = notification.category ? categoryConfig[notification.category] : null;
 
   return (
     <div
+      role="listitem"
       className={`p-4 border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors ${
-        !notification.read ? 'bg-blue-50/50 dark:bg-blue-900/10' : ''
+        !notification.read ? 'bg-blue-50/40 dark:bg-blue-900/10' : ''
       }`}
     >
       <div className="flex gap-3">
-        <div className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${colorMap[notification.type]}`}>
-          <Icon className="w-5 h-5" />
+        {/* Icon */}
+        <div className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${typeColorMap[notification.type]}`}>
+          <Icon className="w-5 h-5" aria-hidden="true" />
         </div>
 
         <div className="flex-1 min-w-0">
           <div className="flex items-start justify-between gap-2">
-            <div className="flex-1">
-              <h4 className="text-sm font-semibold text-gray-900 dark:text-white">
-                {notification.title}
-              </h4>
-              <p className="text-sm text-gray-600 dark:text-gray-400 mt-0.5">
+            <div className="flex-1 min-w-0">
+              {/* Unread dot + title */}
+              <div className="flex items-center gap-1.5">
+                {!notification.read && (
+                  <span className="flex-shrink-0 w-2 h-2 rounded-full bg-blue-500" aria-label="Unread" />
+                )}
+                <h4 className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+                  {notification.title}
+                </h4>
+              </div>
+
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-0.5 line-clamp-2">
                 {notification.message}
               </p>
-              <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">
-                {formatDistanceToNow(notification.timestamp, { addSuffix: true })}
-              </p>
+
+              {/* Meta row: category badge + timeframe */}
+              <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+                {cat && (
+                  <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${cat.className}`}>
+                    {cat.label}
+                  </span>
+                )}
+                <span className="text-xs text-gray-400 dark:text-gray-500">
+                  {formatDistanceToNow(notification.timestamp, { addSuffix: true })}
+                </span>
+              </div>
             </div>
 
+            {/* Delete */}
             <button
               onClick={() => onDelete(notification.id)}
-              className="flex-shrink-0 p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+              className="flex-shrink-0 p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors rounded"
               aria-label="Delete notification"
             >
               <X className="w-4 h-4" />
             </button>
           </div>
 
-          <div className="flex items-center gap-2 mt-2">
+          {/* Actions */}
+          <div className="flex items-center gap-3 mt-2">
             {!notification.read && (
               <button
                 onClick={() => onMarkAsRead(notification.id)}
@@ -90,7 +122,7 @@ export default function NotificationItem({
                 href={notification.actionUrl}
                 className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
               >
-                View details
+                View details →
               </a>
             )}
           </div>

--- a/frontend/src/hooks/useNotificationGenerator.ts
+++ b/frontend/src/hooks/useNotificationGenerator.ts
@@ -3,19 +3,19 @@ import { useNotifications } from '@/hooks/useNotifications';
 /**
  * Helper hook to generate standardized notification payloads for common group events.
  * Automatically checks user preferences before adding notifications to the store.
- * 
- * @returns Object with methods to generate various notification types
  */
 export function useNotificationGenerator() {
   const { addNotification, preferences } = useNotifications();
 
   const generateContributionDueNotification = (groupName: string, hours: number, groupId: string) => {
     if (!preferences.inApp || !preferences.contributionDue24h) return;
-
     addNotification({
+      id: `contrib-due-${groupId}-${Date.now()}`,
       type: 'contribution_due',
+      category: 'contributions',
       title: 'Contribution Due Soon',
       message: `Your contribution to "${groupName}" is due in ${hours} hour${hours > 1 ? 's' : ''}`,
+      timestamp: Date.now(),
       groupId,
       actionUrl: `/groups/${groupId}`,
     });
@@ -23,11 +23,13 @@ export function useNotificationGenerator() {
 
   const generateContributionOverdueNotification = (groupName: string, groupId: string) => {
     if (!preferences.inApp || !preferences.contributionOverdue) return;
-
     addNotification({
+      id: `contrib-overdue-${groupId}-${Date.now()}`,
       type: 'contribution_overdue',
+      category: 'contributions',
       title: 'Contribution Overdue',
       message: `Your contribution to "${groupName}" is overdue. Please contribute as soon as possible.`,
+      timestamp: Date.now(),
       groupId,
       actionUrl: `/groups/${groupId}`,
     });
@@ -35,11 +37,13 @@ export function useNotificationGenerator() {
 
   const generatePayoutReceivedNotification = (amount: number, groupName: string, groupId: string) => {
     if (!preferences.inApp || !preferences.payoutReceived) return;
-
     addNotification({
+      id: `payout-${groupId}-${Date.now()}`,
       type: 'payout_received',
+      category: 'payouts',
       title: 'Payout Received',
       message: `You received ${amount} XLM from "${groupName}"`,
+      timestamp: Date.now(),
       groupId,
       actionUrl: `/groups/${groupId}`,
     });
@@ -47,11 +51,13 @@ export function useNotificationGenerator() {
 
   const generateMemberJoinedNotification = (memberName: string, groupName: string, groupId: string) => {
     if (!preferences.inApp || !preferences.memberJoined) return;
-
     addNotification({
+      id: `member-joined-${groupId}-${Date.now()}`,
       type: 'member_joined',
+      category: 'members',
       title: 'New Member Joined',
       message: `${memberName} joined "${groupName}"`,
+      timestamp: Date.now(),
       groupId,
       actionUrl: `/groups/${groupId}`,
     });
@@ -59,11 +65,13 @@ export function useNotificationGenerator() {
 
   const generateCycleCompletedNotification = (groupName: string, groupId: string) => {
     if (!preferences.inApp || !preferences.cycleCompleted) return;
-
     addNotification({
+      id: `cycle-${groupId}-${Date.now()}`,
       type: 'cycle_completed',
+      category: 'groups',
       title: 'Cycle Completed',
       message: `"${groupName}" has completed a savings cycle`,
+      timestamp: Date.now(),
       groupId,
       actionUrl: `/groups/${groupId}`,
     });
@@ -71,11 +79,13 @@ export function useNotificationGenerator() {
 
   const generateAnnouncementNotification = (title: string, message: string, groupId?: string) => {
     if (!preferences.inApp || !preferences.announcements) return;
-
     addNotification({
+      id: `announcement-${Date.now()}`,
       type: 'announcement',
+      category: groupId ? 'groups' : 'system',
       title,
       message,
+      timestamp: Date.now(),
       groupId,
       actionUrl: groupId ? `/groups/${groupId}` : undefined,
     });

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
+export type NotificationCategory = 'contributions' | 'payouts' | 'members' | 'groups' | 'system'
+
 /**
  * Raw data required to create a new notification.
  */
@@ -18,6 +20,7 @@ export interface NotificationPayload {
     | 'announcement'
     | 'group_invitation'
     | 'invitation_response'
+  category: NotificationCategory
   title: string
   message: string
   timestamp: number
@@ -83,10 +86,100 @@ const defaultPreferences: NotificationPreferences = {
  * - Managing push service worker subscriptions
  * - Requesting browser notification permissions
  */
+const now = Date.now()
+const SEED_NOTIFICATIONS: Notification[] = [
+  {
+    id: 'seed-1',
+    type: 'contribution_due',
+    category: 'contributions',
+    title: 'Contribution Due in 24 Hours',
+    message: 'Your 50 XLM contribution to "Lagos Savers Circle" is due tomorrow.',
+    timestamp: now - 1000 * 60 * 30,
+    groupId: 'group-1',
+    actionUrl: '/groups/group-1',
+    read: false,
+  },
+  {
+    id: 'seed-2',
+    type: 'payout_received',
+    category: 'payouts',
+    title: 'Payout Received 🎉',
+    message: 'You received 500 XLM from "Abuja Wealth Club". Funds are in your wallet.',
+    timestamp: now - 1000 * 60 * 60 * 2,
+    groupId: 'group-2',
+    actionUrl: '/groups/group-2',
+    read: false,
+  },
+  {
+    id: 'seed-3',
+    type: 'member_joined',
+    category: 'members',
+    title: 'New Member Joined',
+    message: 'Amara Okafor joined "Lagos Savers Circle". The group now has 8 members.',
+    timestamp: now - 1000 * 60 * 60 * 5,
+    groupId: 'group-1',
+    actionUrl: '/groups/group-1',
+    read: false,
+  },
+  {
+    id: 'seed-4',
+    type: 'contribution_overdue',
+    category: 'contributions',
+    title: 'Contribution Overdue',
+    message: 'Your contribution to "Kano Traders Fund" is 2 days overdue. A penalty may apply.',
+    timestamp: now - 1000 * 60 * 60 * 24,
+    groupId: 'group-3',
+    actionUrl: '/groups/group-3',
+    read: true,
+  },
+  {
+    id: 'seed-5',
+    type: 'group_invitation',
+    category: 'groups',
+    title: 'Group Invitation',
+    message: 'Chidi Eze invited you to join "Port Harcourt Professionals". 10 members, 100 XLM/cycle.',
+    timestamp: now - 1000 * 60 * 60 * 48,
+    groupId: 'group-4',
+    actionUrl: '/invitations',
+    read: false,
+  },
+  {
+    id: 'seed-6',
+    type: 'cycle_completed',
+    category: 'groups',
+    title: 'Cycle Completed',
+    message: '"Abuja Wealth Club" has completed cycle 3 of 10. Next payout in 30 days.',
+    timestamp: now - 1000 * 60 * 60 * 72,
+    groupId: 'group-2',
+    actionUrl: '/groups/group-2',
+    read: true,
+  },
+  {
+    id: 'seed-7',
+    type: 'announcement',
+    category: 'system',
+    title: 'Platform Update',
+    message: 'Ajo v2.1 is live! New features: multi-currency support and improved analytics.',
+    timestamp: now - 1000 * 60 * 60 * 96,
+    read: true,
+  },
+  {
+    id: 'seed-8',
+    type: 'contribution_received',
+    category: 'contributions',
+    title: 'Contribution Confirmed',
+    message: 'Your 50 XLM contribution to "Lagos Savers Circle" for cycle 4 was confirmed on-chain.',
+    timestamp: now - 1000 * 60 * 60 * 120,
+    groupId: 'group-1',
+    actionUrl: '/groups/group-1',
+    read: true,
+  },
+]
+
 export const useNotifications = create<NotificationState>()(
   persist(
     (set, get) => ({
-      notifications: [],
+      notifications: SEED_NOTIFICATIONS,
       preferences: defaultPreferences,
       pushSubscription: null,
 


### PR DESCRIPTION
closes #604 

- Add NotificationCategory type and category field to NotificationPayload
- Rebuild NotificationCenter with category tabs, read/unread filter, search
- Enhance NotificationItem with category badge and unread dot indicator
- Add seed notifications across all 5 categories
- Update useNotificationGenerator to include category in all payloads
- Fix invitations page addNotification calls to include category field