### PR TITLE
feat: implement automated reminder system (#587)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -48,3 +48,8 @@ REDIS_URL=redis://localhost:6379
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_AUTH_TOKEN=your_twilio_auth_token
 TWILIO_FROM_NUMBER=+15005550006
+
+# Web Push / VAPID (required for browser push notifications — Issue #587)
+# Generate with: npx web-push generate-vapid-keys
+VAPID_PUBLIC_KEY=your_vapid_public_key_here
+VAPID_PRIVATE_KEY=your_vapid_private_key_here

--- a/backend/prisma/migrations/20260424000000_add_reminder_preferences_push_subscriptions/migration.sql
+++ b/backend/prisma/migrations/20260424000000_add_reminder_preferences_push_subscriptions/migration.sql
@@ -1,0 +1,43 @@
+-- Migration: add_reminder_preferences_push_subscriptions (Issue #587)
+
+CREATE TABLE "ReminderPreferences" (
+    "id"                        TEXT NOT NULL,
+    "userId"                    TEXT NOT NULL,
+    "channels"                  TEXT[] NOT NULL DEFAULT ARRAY['push']::TEXT[],
+    "contributionReminderHours" INTEGER NOT NULL DEFAULT 24,
+    "payoutReminderHours"       INTEGER NOT NULL DEFAULT 2,
+    "enabled"                   BOOLEAN NOT NULL DEFAULT true,
+    "phoneNumber"               TEXT,
+    "email"                     TEXT,
+    "createdAt"                 TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"                 TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ReminderPreferences_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ReminderPreferences_userId_key" ON "ReminderPreferences"("userId");
+CREATE INDEX "ReminderPreferences_userId_idx" ON "ReminderPreferences"("userId");
+
+ALTER TABLE "ReminderPreferences"
+    ADD CONSTRAINT "ReminderPreferences_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("walletAddress") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE "PushSubscription" (
+    "id"        TEXT NOT NULL,
+    "userId"    TEXT NOT NULL,
+    "endpoint"  TEXT NOT NULL,
+    "p256dh"    TEXT NOT NULL,
+    "auth"      TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PushSubscription_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PushSubscription_endpoint_key" ON "PushSubscription"("endpoint");
+CREATE INDEX "PushSubscription_userId_idx" ON "PushSubscription"("userId");
+
+ALTER TABLE "PushSubscription"
+    ADD CONSTRAINT "PushSubscription_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("walletAddress") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -881,3 +881,38 @@ model MarketingContact {
   @@index([email])
   @@index([status])
 }
+
+/// Per-user reminder preferences for Issue #587
+model ReminderPreferences {
+  id                       String   @id @default(cuid())
+  userId                   String   @unique
+  /// Channels to use: email | push | sms (stored as string array)
+  channels                 String[] @default(["push"])
+  /// Hours before contribution deadline to send reminder (default 24)
+  contributionReminderHours Int     @default(24)
+  /// Hours before payout to send reminder (default 2)
+  payoutReminderHours       Int     @default(2)
+  enabled                  Boolean  @default(true)
+  phoneNumber              String?
+  email                    String?
+  createdAt                DateTime @default(now())
+  updatedAt                DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [walletAddress], onDelete: Cascade)
+
+  @@index([userId])
+}
+
+/// Web Push subscriptions for browser push notifications
+model PushSubscription {
+  id        String   @id @default(cuid())
+  userId    String
+  endpoint  String   @unique
+  p256dh    String
+  auth      String
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [walletAddress], onDelete: Cascade)
+
+  @@index([userId])
+}

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -132,3 +132,64 @@ notificationsRouter.put('/reminders/preferences', async (req: AuthRequest, res: 
     res.status(500).json({ success: false, error: 'Failed to update preferences' })
   }
 })
+
+// ── Web Push subscription management ─────────────────────────────────────
+
+const pushSubSchema = z.object({
+  endpoint: z.string().url(),
+  keys: z.object({
+    p256dh: z.string(),
+    auth: z.string(),
+  }),
+})
+
+/**
+ * GET /api/notifications/push/vapid-public-key
+ * Returns the VAPID public key for the client to use when subscribing.
+ */
+notificationsRouter.get('/push/vapid-public-key', (_req, res: Response) => {
+  const key = process.env.VAPID_PUBLIC_KEY
+  if (!key) return res.status(503).json({ success: false, error: 'Push notifications not configured' })
+  res.json({ success: true, data: { publicKey: key } })
+})
+
+/**
+ * POST /api/notifications/push/subscribe
+ * Saves a Web Push subscription for the authenticated user.
+ */
+notificationsRouter.post('/push/subscribe', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user!.walletAddress!
+    const { endpoint, keys } = pushSubSchema.parse(req.body)
+    await prisma.pushSubscription.upsert({
+      where: { endpoint },
+      update: { p256dh: keys.p256dh, auth: keys.auth },
+      create: { userId, endpoint, p256dh: keys.p256dh, auth: keys.auth },
+    })
+    res.json({ success: true })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ success: false, error: 'Invalid subscription', details: err.errors })
+    }
+    logger.error('Error saving push subscription:', err)
+    res.status(500).json({ success: false, error: 'Failed to save subscription' })
+  }
+})
+
+/**
+ * DELETE /api/notifications/push/unsubscribe
+ * Removes a Web Push subscription by endpoint.
+ */
+notificationsRouter.delete('/push/unsubscribe', async (req: AuthRequest, res: Response) => {
+  try {
+    const { endpoint } = z.object({ endpoint: z.string().url() }).parse(req.body)
+    await prisma.pushSubscription.deleteMany({ where: { endpoint, userId: req.user!.walletAddress! } })
+    res.json({ success: true })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return res.status(400).json({ success: false, error: 'Invalid request', details: err.errors })
+    }
+    logger.error('Error removing push subscription:', err)
+    res.status(500).json({ success: false, error: 'Failed to remove subscription' })
+  }
+})


### PR DESCRIPTION
- Add ReminderPreferences and PushSubscription Prisma models
- Add migration for new tables
- Add push subscription endpoints (VAPID key, subscribe, unsubscribe)
- Document VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY in .env.example

Reminder service, BullMQ job processor, cron scheduler, and worker registration were already in place. This completes the full system: scheduled reminders via email, SMS (Twilio), and push (web-push) with per-user customizable timing preferences.

Closes #587 