### PR TITLE
feat(routes): add group activity feed and summary endpoints

### DIFF
--- a/backend/src/routes/activity.routes.ts
+++ b/backend/src/routes/activity.routes.ts
@@ -2,11 +2,8 @@ import { Router } from "express";
 import {
   getActivityFeed,
   getActivityById,
-  getGroupActivityFeed,
-  getGroupActivitySummary,
 } from "../controllers/activity.controller";
 import { authenticate } from "../middleware/auth";        // existing middleware
-import { requireGroupMember } from "../middleware/groups"; // existing middleware
 
 const router = Router();
 
@@ -17,23 +14,5 @@ router.get("/", authenticate, getActivityFeed);
 // ── Single record ─────────────────────────────────────────────────────────────
 // GET /api/v1/activity/:id
 router.get("/:id", authenticate, getActivityById);
-
-// ── Group-scoped feed ─────────────────────────────────────────────────────────
-// GET /api/v1/groups/:groupId/activity
-router.get(
-  "/groups/:groupId/activity",
-  authenticate,
-  requireGroupMember,
-  getGroupActivityFeed
-);
-
-// ── Group activity summary (dashboard widget) ─────────────────────────────────
-// GET /api/v1/groups/:groupId/activity/summary
-router.get(
-  "/groups/:groupId/activity/summary",
-  authenticate,
-  requireGroupMember,
-  getGroupActivitySummary
-);
 
 export default router;

--- a/backend/src/routes/groups.ts
+++ b/backend/src/routes/groups.ts
@@ -12,6 +12,11 @@ import {
   paginationQuerySchema,
 } from '../validators/groups'
 import { scheduleRouter } from './schedule'
+import {
+  getGroupActivityFeed,
+  getGroupActivitySummary,
+} from '../controllers/activity.controller'
+import { requireGroupMember } from '../middleware/groups'
 
 const router = Router()
 const controller = new GroupsController()
@@ -239,5 +244,21 @@ router.get(
 
 // Contribution schedule sub-router
 router.use('/:id/schedule', scheduleRouter)
+
+// Group activity feed
+router.get(
+  '/:id/activity',
+  validateRequest({ params: groupIdParamSchema }),
+  requireGroupMember,
+  getGroupActivityFeed
+)
+
+// Group activity summary
+router.get(
+  '/:id/activity/summary',
+  validateRequest({ params: groupIdParamSchema }),
+  requireGroupMember,
+  getGroupActivitySummary
+)
 
 export const groupsRouter = router


### PR DESCRIPTION
## Description:
Fixed the Group Activity Feed API by moving routes to the correct path under /groups/:id/activity.
### Changes:
- backend/src/routes/groups.ts: Added group-scoped activity routes at /:id/activity and /:id/activity/summary
- backend/src/routes/activity.routes.ts: Simplified to global-only endpoints
### API Endpoints:
- GET /api/v1/activity - Global feed
- GET /api/v1/activity/:id - Single record
- GET /api/v1/groups/:groupId/activity - Group feed (paginated, filterable)
- GET /api/v1/groups/:groupId/activity/summary - Dashboard summary
Features: Activity tracking, feed generation, filtering (group/user/eventTypes/date range), pagination with cursor.

Closes #588 