### PR TITLE
feat: implement automated reminder system (#587)

### DIFF
--- a/frontend/src/app/[locale]/settings/notifications/page.tsx
+++ b/frontend/src/app/[locale]/settings/notifications/page.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import { useNotificationGenerator } from '@/hooks/useNotificationGenerator';
 import NotificationPreferences from '@/components/NotificationPreferences';
+import { ReminderSettings } from '@/components/reminders/ReminderSettings';
+import { ReminderPreview } from '@/components/reminders/ReminderPreview';
 import { Bell } from 'lucide-react';
 
 export default function NotificationSettingsPage() {
@@ -63,6 +65,12 @@ export default function NotificationSettingsPage() {
         </div>
 
         <NotificationPreferences />
+
+        {/* Reminder Settings */}
+        <div className="mt-8 grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <ReminderSettings />
+          <ReminderPreview />
+        </div>
 
         {/* Test Notifications Section */}
         <div className="mt-8 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">

--- a/frontend/src/components/reminders/ReminderPreview.tsx
+++ b/frontend/src/components/reminders/ReminderPreview.tsx
@@ -3,6 +3,14 @@
 import { useReminderSettings } from '@/hooks/useReminderSettings';
 import { Mail, Bell, Smartphone, Clock } from 'lucide-react';
 
+const CHANNEL_ICONS = { email: Mail, push: Bell, sms: Smartphone } as const;
+
+function hoursLabel(hours: number): string {
+  if (hours < 24) return `${hours} hour${hours !== 1 ? 's' : ''}`;
+  const days = hours / 24;
+  return `${days} day${days !== 1 ? 's' : ''}`;
+}
+
 export function ReminderPreview() {
   const { preferences } = useReminderSettings();
 
@@ -14,45 +22,39 @@ export function ReminderPreview() {
     );
   }
 
-  const timingLabels: Record<string, string> = {
-    immediate: 'Immediately',
-    '1day': '1 Day Before',
-    '3days': '3 Days Before',
-    '1week': '1 Week Before',
-  };
-
-  const channelIcons: Record<string, any> = {
-    email: Mail,
-    push: Bell,
-    sms: Smartphone,
-  };
-
   return (
     <div className="p-4 bg-blue-50 rounded-lg border border-blue-200 space-y-3">
-      <h3 className="font-semibold text-blue-900">Reminder Preview</h3>
-      
+      <h3 className="font-semibold text-blue-900">Reminder Summary</h3>
+
       <div className="flex items-center gap-2 text-sm">
-        <Clock className="w-4 h-4" />
-        <span>You'll receive reminders <strong>{timingLabels[preferences.timing]}</strong></span>
+        <Clock className="w-4 h-4 shrink-0" />
+        <span>
+          Contribution reminders <strong>{hoursLabel(preferences.contributionReminderHours)} before</strong> deadline
+        </span>
       </div>
 
       <div className="flex items-center gap-2 text-sm">
+        <Clock className="w-4 h-4 shrink-0" />
+        <span>
+          Payout reminders <strong>{hoursLabel(preferences.payoutReminderHours)} before</strong> payout
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2 text-sm flex-wrap">
         <span className="font-medium">Via:</span>
-        <div className="flex gap-2">
-          {preferences.channels.map((channel) => {
-            const Icon = channelIcons[channel];
+        {preferences.channels.length === 0 ? (
+          <span className="text-gray-500">No channels selected</span>
+        ) : (
+          preferences.channels.map((channel) => {
+            const Icon = CHANNEL_ICONS[channel];
             return (
-              <div key={channel} className="flex items-center gap-1 bg-white px-2 py-1 rounded">
+              <div key={channel} className="flex items-center gap-1 bg-white px-2 py-1 rounded border">
                 <Icon className="w-3 h-3" />
                 <span className="capitalize text-xs">{channel}</span>
               </div>
             );
-          })}
-        </div>
-      </div>
-
-      <div className="text-xs text-gray-600">
-        Frequency: <strong className="capitalize">{preferences.frequency}</strong>
+          })
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/reminders/ReminderSettings.tsx
+++ b/frontend/src/components/reminders/ReminderSettings.tsx
@@ -2,23 +2,39 @@
 
 import { useState } from 'react';
 import { Bell, Mail, Smartphone, Clock } from 'lucide-react';
-import { useReminderSettings, ReminderPreferences } from '@/hooks/useReminderSettings';
+import { useReminderSettings } from '@/hooks/useReminderSettings';
+
+const CONTRIBUTION_TIMING_OPTIONS = [
+  { label: '1 hour before', value: 1 },
+  { label: '6 hours before', value: 6 },
+  { label: '24 hours before', value: 24 },
+  { label: '48 hours before', value: 48 },
+  { label: '1 week before', value: 168 },
+];
+
+const PAYOUT_TIMING_OPTIONS = [
+  { label: '1 hour before', value: 1 },
+  { label: '2 hours before', value: 2 },
+  { label: '6 hours before', value: 6 },
+  { label: '24 hours before', value: 24 },
+  { label: '48 hours before', value: 48 },
+];
 
 export function ReminderSettings() {
-  const { preferences, updatePreferences, loading } = useReminderSettings();
+  const { preferences, updatePreferences, loading, error } = useReminderSettings();
   const [saved, setSaved] = useState(false);
 
-  const handleToggle = async (key: keyof ReminderPreferences, value: any) => {
-    await updatePreferences({ [key]: value });
+  const handleChange = async (patch: Parameters<typeof updatePreferences>[0]) => {
+    await updatePreferences(patch);
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
   };
 
   const handleChannelToggle = (channel: 'email' | 'push' | 'sms') => {
     const newChannels = preferences.channels.includes(channel)
-      ? preferences.channels.filter(c => c !== channel)
+      ? preferences.channels.filter((c) => c !== channel)
       : [...preferences.channels, channel];
-    handleToggle('channels', newChannels);
+    handleChange({ channels: newChannels });
   };
 
   return (
@@ -26,9 +42,10 @@ export function ReminderSettings() {
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold flex items-center gap-2">
           <Bell className="w-6 h-6" />
-          Contribution Reminders
+          Reminder Settings
         </h2>
-        {saved && <span className="text-green-600 text-sm">Saved!</span>}
+        {saved && <span className="text-green-600 text-sm font-medium">Saved!</span>}
+        {error && <span className="text-red-600 text-sm">{error}</span>}
       </div>
 
       {/* Enable/Disable */}
@@ -37,7 +54,7 @@ export function ReminderSettings() {
           <input
             type="checkbox"
             checked={preferences.enabled}
-            onChange={(e) => handleToggle('enabled', e.target.checked)}
+            onChange={(e) => handleChange({ enabled: e.target.checked })}
             disabled={loading}
             className="w-4 h-4"
           />
@@ -47,37 +64,39 @@ export function ReminderSettings() {
 
       {preferences.enabled && (
         <>
-          {/* Timing */}
-          <div className="space-y-3">
+          {/* Contribution reminder timing */}
+          <div className="space-y-2">
             <label className="flex items-center gap-2 font-medium">
               <Clock className="w-4 h-4" />
-              Reminder Timing
+              Contribution Reminder Timing
             </label>
             <select
-              value={preferences.timing}
-              onChange={(e) => handleToggle('timing', e.target.value)}
+              value={preferences.contributionReminderHours}
+              onChange={(e) => handleChange({ contributionReminderHours: Number(e.target.value) })}
               disabled={loading}
               className="w-full p-2 border rounded-md"
             >
-              <option value="immediate">Immediately</option>
-              <option value="1day">1 Day Before</option>
-              <option value="3days">3 Days Before</option>
-              <option value="1week">1 Week Before</option>
+              {CONTRIBUTION_TIMING_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
             </select>
           </div>
 
-          {/* Frequency */}
-          <div className="space-y-3">
-            <label className="font-medium">Frequency</label>
+          {/* Payout reminder timing */}
+          <div className="space-y-2">
+            <label className="flex items-center gap-2 font-medium">
+              <Clock className="w-4 h-4" />
+              Payout Reminder Timing
+            </label>
             <select
-              value={preferences.frequency}
-              onChange={(e) => handleToggle('frequency', e.target.value)}
+              value={preferences.payoutReminderHours}
+              onChange={(e) => handleChange({ payoutReminderHours: Number(e.target.value) })}
               disabled={loading}
               className="w-full p-2 border rounded-md"
             >
-              <option value="once">Once</option>
-              <option value="daily">Daily</option>
-              <option value="weekly">Weekly</option>
+              {PAYOUT_TIMING_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
             </select>
           </div>
 
@@ -85,41 +104,54 @@ export function ReminderSettings() {
           <div className="space-y-3">
             <label className="font-medium">Notification Channels</label>
             <div className="space-y-2">
-              <label className="flex items-center gap-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={preferences.channels.includes('email')}
-                  onChange={() => handleChannelToggle('email')}
-                  disabled={loading}
-                  className="w-4 h-4"
-                />
-                <Mail className="w-4 h-4" />
-                <span>Email</span>
-              </label>
-              <label className="flex items-center gap-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={preferences.channels.includes('push')}
-                  onChange={() => handleChannelToggle('push')}
-                  disabled={loading}
-                  className="w-4 h-4"
-                />
-                <Bell className="w-4 h-4" />
-                <span>Push Notification</span>
-              </label>
-              <label className="flex items-center gap-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={preferences.channels.includes('sms')}
-                  onChange={() => handleChannelToggle('sms')}
-                  disabled={loading}
-                  className="w-4 h-4"
-                />
-                <Smartphone className="w-4 h-4" />
-                <span>SMS</span>
-              </label>
+              {([
+                { id: 'email', label: 'Email', Icon: Mail },
+                { id: 'push', label: 'Push Notification', Icon: Bell },
+                { id: 'sms', label: 'SMS', Icon: Smartphone },
+              ] as const).map(({ id, label, Icon }) => (
+                <label key={id} className="flex items-center gap-3 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={preferences.channels.includes(id)}
+                    onChange={() => handleChannelToggle(id)}
+                    disabled={loading}
+                    className="w-4 h-4"
+                  />
+                  <Icon className="w-4 h-4" />
+                  <span>{label}</span>
+                </label>
+              ))}
             </div>
           </div>
+
+          {/* Contact details */}
+          {preferences.channels.includes('email') && (
+            <div className="space-y-2">
+              <label className="font-medium text-sm">Email address for reminders</label>
+              <input
+                type="email"
+                value={preferences.email ?? ''}
+                onChange={(e) => handleChange({ email: e.target.value || undefined })}
+                disabled={loading}
+                placeholder="you@example.com"
+                className="w-full p-2 border rounded-md text-sm"
+              />
+            </div>
+          )}
+
+          {preferences.channels.includes('sms') && (
+            <div className="space-y-2">
+              <label className="font-medium text-sm">Phone number for SMS reminders</label>
+              <input
+                type="tel"
+                value={preferences.phoneNumber ?? ''}
+                onChange={(e) => handleChange({ phoneNumber: e.target.value || undefined })}
+                disabled={loading}
+                placeholder="+1 555 000 0000"
+                className="w-full p-2 border rounded-md text-sm"
+              />
+            </div>
+          )}
         </>
       )}
     </div>

--- a/frontend/src/hooks/useReminderSettings.ts
+++ b/frontend/src/hooks/useReminderSettings.ts
@@ -1,31 +1,74 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
+import { API_BASE_URL } from '@/lib/apiEndpoints';
 
 export interface ReminderPreferences {
   enabled: boolean;
-  timing: 'immediate' | '1day' | '3days' | '1week';
+  /** Hours before contribution deadline to send reminder (1–168) */
+  contributionReminderHours: number;
+  /** Hours before payout to send reminder (1–48) */
+  payoutReminderHours: number;
   channels: ('email' | 'push' | 'sms')[];
-  frequency: 'once' | 'daily' | 'weekly';
+  phoneNumber?: string;
+  email?: string;
 }
 
 const DEFAULT_PREFERENCES: ReminderPreferences = {
   enabled: true,
-  timing: '1day',
+  contributionReminderHours: 24,
+  payoutReminderHours: 2,
   channels: ['email', 'push'],
-  frequency: 'daily',
 };
+
+async function fetchPrefs(token: string): Promise<ReminderPreferences> {
+  const res = await fetch(`${API_BASE_URL}/api/notifications/reminders/preferences`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error('Failed to load reminder preferences');
+  const json = await res.json();
+  return json.data as ReminderPreferences;
+}
+
+async function savePrefs(token: string, prefs: Partial<ReminderPreferences>): Promise<ReminderPreferences> {
+  const res = await fetch(`${API_BASE_URL}/api/notifications/reminders/preferences`, {
+    method: 'PUT',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(prefs),
+  });
+  if (!res.ok) throw new Error('Failed to save reminder preferences');
+  const json = await res.json();
+  return json.data as ReminderPreferences;
+}
+
+function getToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('auth_token') ?? sessionStorage.getItem('auth_token');
+}
 
 export function useReminderSettings() {
   const [preferences, setPreferences] = useState<ReminderPreferences>(DEFAULT_PREFERENCES);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Load preferences from backend on mount
+  useEffect(() => {
+    const token = getToken();
+    if (!token) return;
+    setLoading(true);
+    fetchPrefs(token)
+      .then(setPreferences)
+      .catch(() => { /* silently fall back to defaults */ })
+      .finally(() => setLoading(false));
+  }, []);
+
   const updatePreferences = useCallback(async (newPrefs: Partial<ReminderPreferences>) => {
     setLoading(true);
     setError(null);
     try {
-      const updated = { ...preferences, ...newPrefs };
+      const token = getToken();
+      const updated = token
+        ? await savePrefs(token, newPrefs)
+        : { ...preferences, ...newPrefs };
       setPreferences(updated);
-      // TODO: Persist to backend
       return updated;
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to update preferences';
@@ -36,15 +79,9 @@ export function useReminderSettings() {
     }
   }, [preferences]);
 
-  const resetToDefaults = useCallback(() => {
-    setPreferences(DEFAULT_PREFERENCES);
-  }, []);
+  const resetToDefaults = useCallback(async () => {
+    await updatePreferences(DEFAULT_PREFERENCES).catch(() => setPreferences(DEFAULT_PREFERENCES));
+  }, [updatePreferences]);
 
-  return {
-    preferences,
-    updatePreferences,
-    resetToDefaults,
-    loading,
-    error,
-  };
+  return { preferences, updatePreferences, resetToDefaults, loading, error };
 }

--- a/frontend/src/lib/apiEndpoints.ts
+++ b/frontend/src/lib/apiEndpoints.ts
@@ -48,6 +48,19 @@ export const apiPaths = {
     funnel: '/api/analytics/funnel',
     export: '/api/analytics/export',
   },
+  notifications: {
+    list: '/api/notifications',
+    status: '/api/notifications/status',
+    test: '/api/notifications/test',
+    reminders: {
+      preferences: '/api/notifications/reminders/preferences',
+    },
+    push: {
+      vapidKey: '/api/notifications/push/vapid-public-key',
+      subscribe: '/api/notifications/push/subscribe',
+      unsubscribe: '/api/notifications/push/unsubscribe',
+    },
+  },
   admin: {
     dashboard: '/api/admin/dashboard',
     config: '/api/admin/config',


### PR DESCRIPTION
- Connect useReminderSettings hook to backend API (GET/PUT preferences)
- Align ReminderPreferences type with backend hours-based model
- Update ReminderSettings UI with hours-based timing dropdowns and conditional email/phone fields per channel
- Update ReminderPreview to display hours-based timing labels
- Add notifications API paths to apiEndpoints.ts
- Integrate ReminderSettings + ReminderPreview into notification settings page

Closes #587 