### PR TITLE
feat(calendar): integrate Google Calendar and Outlook for contributio…

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -115,6 +115,10 @@ app.use('/api/payments', paymentsRouter)
 import { paymentWebhooksRouter } from './routes/paymentWebhooks'
 app.use('/api/webhooks/payments', paymentWebhooksRouter)
 
+// Calendar integration — Issue #619
+import { calendarRouter } from './routes/calendar'
+app.use('/api/calendar', calendarRouter)
+
 // 404 handler
 app.use((req, res) => {
   res.status(404).json({

--- a/backend/src/routes/calendar.ts
+++ b/backend/src/routes/calendar.ts
@@ -1,0 +1,118 @@
+/**
+ * Calendar Routes — Issue #619
+ *
+ * Endpoints for Google Calendar / Outlook integration and iCal feed generation.
+ */
+
+import { Router, Response } from 'express'
+import { z } from 'zod'
+import { AuthRequest } from '../middleware/auth'
+import {
+  generateUserCalendarFeed,
+  generateContributionEventIcal,
+  buildContributionReminderEvent,
+  buildPayoutEvent,
+  buildICalendar,
+  buildGoogleCalendarUrl,
+  buildOutlookCalendarUrl,
+} from '../services/calendarService'
+import { createModuleLogger } from '../utils/logger'
+
+const router = Router()
+const logger = createModuleLogger('CalendarRoutes')
+
+// GET /api/calendar/feed — iCal feed for all user events (subscribe URL)
+router.get('/feed', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.id
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' })
+
+    const ical = await generateUserCalendarFeed(userId)
+    res.setHeader('Content-Type', 'text/calendar; charset=utf-8')
+    res.setHeader('Content-Disposition', 'attachment; filename="ajo-reminders.ics"')
+    res.setHeader('Cache-Control', 'no-cache, no-store')
+    return res.send(ical)
+  } catch (error) {
+    logger.error('[Calendar] Feed error:', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+})
+
+// GET /api/calendar/groups/:groupId/event — single group contribution event
+router.get('/groups/:groupId/event', async (req: AuthRequest, res: Response) => {
+  try {
+    const userId = req.user?.id
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' })
+
+    const { groupId } = req.params
+    const format = (req.query.format as string) ?? 'json'
+
+    const result = await generateContributionEventIcal(groupId, userId)
+    if (!result) return res.status(404).json({ error: 'Group not found or no upcoming deadline' })
+
+    if (format === 'ics') {
+      res.setHeader('Content-Type', 'text/calendar; charset=utf-8')
+      res.setHeader('Content-Disposition', `attachment; filename="contribution-${groupId}.ics"`)
+      return res.send(result.ical)
+    }
+
+    return res.json({
+      googleCalendarUrl: result.googleUrl,
+      outlookCalendarUrl: result.outlookUrl,
+      icsDownloadUrl: `/api/calendar/groups/${groupId}/event?format=ics`,
+    })
+  } catch (error) {
+    logger.error('[Calendar] Group event error:', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+})
+
+// POST /api/calendar/events/custom — generate calendar links for a custom event
+const customEventSchema = z.object({
+  type: z.enum(['contribution', 'payout']),
+  groupId: z.string(),
+  groupName: z.string(),
+  amount: z.string(),
+  date: z.string().datetime(),
+  cycleNumber: z.number().optional(),
+})
+
+router.post('/events/custom', async (req: AuthRequest, res: Response) => {
+  try {
+    const body = customEventSchema.parse(req.body)
+    const appUrl = process.env.FRONTEND_URL ?? 'https://app.ajo.finance'
+    const date = new Date(body.date)
+
+    const event =
+      body.type === 'contribution'
+        ? buildContributionReminderEvent({
+            groupId: body.groupId,
+            groupName: body.groupName,
+            contributionAmount: body.amount,
+            dueDate: date,
+            cycleNumber: body.cycleNumber ?? 1,
+            appUrl: `${appUrl}/groups/${body.groupId}`,
+          })
+        : buildPayoutEvent({
+            groupId: body.groupId,
+            groupName: body.groupName,
+            payoutAmount: body.amount,
+            payoutDate: date,
+            appUrl: `${appUrl}/groups/${body.groupId}`,
+          })
+
+    return res.json({
+      googleCalendarUrl: buildGoogleCalendarUrl(event),
+      outlookCalendarUrl: buildOutlookCalendarUrl(event),
+      ical: buildICalendar([event]),
+    })
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ error: 'Invalid request', details: error.errors })
+    }
+    logger.error('[Calendar] Custom event error:', error)
+    return res.status(500).json({ error: 'Internal server error' })
+  }
+})
+
+export const calendarRouter = router

--- a/backend/src/services/calendarService.ts
+++ b/backend/src/services/calendarService.ts
@@ -1,0 +1,258 @@
+/**
+ * Calendar Integration Service — Issue #619
+ *
+ * Generates iCalendar (.ics) events for contribution reminders and payout
+ * notifications. Supports Google Calendar (via URL) and Outlook (via .ics download).
+ *
+ * No OAuth required for the core flow — we generate standard iCal files that
+ * users can import into any calendar app. Google Calendar "Add to Calendar"
+ * links are also generated for one-click adding.
+ */
+
+import { createModuleLogger } from '../utils/logger'
+import { prisma } from '../config/database'
+
+const logger = createModuleLogger('CalendarService')
+
+// ── iCal helpers ──────────────────────────────────────────────────────────
+
+function formatICalDate(date: Date): string {
+  return date.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z'
+}
+
+function escapeICalText(text: string): string {
+  return text.replace(/\\/g, '\\\\').replace(/;/g, '\\;').replace(/,/g, '\\,').replace(/\n/g, '\\n')
+}
+
+function generateUID(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}@ajo-app`
+}
+
+export interface CalendarEvent {
+  uid: string
+  summary: string
+  description: string
+  dtstart: Date
+  dtend: Date
+  location?: string
+  url?: string
+  alarmMinutes?: number
+}
+
+/**
+ * Generates a single VEVENT block for an iCal file.
+ */
+function buildVEvent(event: CalendarEvent): string {
+  const lines = [
+    'BEGIN:VEVENT',
+    `UID:${event.uid}`,
+    `DTSTAMP:${formatICalDate(new Date())}`,
+    `DTSTART:${formatICalDate(event.dtstart)}`,
+    `DTEND:${formatICalDate(event.dtend)}`,
+    `SUMMARY:${escapeICalText(event.summary)}`,
+    `DESCRIPTION:${escapeICalText(event.description)}`,
+  ]
+
+  if (event.location) lines.push(`LOCATION:${escapeICalText(event.location)}`)
+  if (event.url) lines.push(`URL:${event.url}`)
+
+  if (event.alarmMinutes !== undefined) {
+    lines.push(
+      'BEGIN:VALARM',
+      'ACTION:DISPLAY',
+      `DESCRIPTION:${escapeICalText(event.summary)}`,
+      `TRIGGER:-PT${event.alarmMinutes}M`,
+      'END:VALARM'
+    )
+  }
+
+  lines.push('END:VEVENT')
+  return lines.join('\r\n')
+}
+
+/**
+ * Wraps VEVENT blocks in a VCALENDAR envelope.
+ */
+export function buildICalendar(events: CalendarEvent[], calName = 'Ajo Reminders'): string {
+  const vevents = events.map(buildVEvent).join('\r\n')
+  return [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//Ajo App//EN',
+    `X-WR-CALNAME:${calName}`,
+    'X-WR-TIMEZONE:UTC',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    vevents,
+    'END:VCALENDAR',
+  ].join('\r\n')
+}
+
+// ── Google Calendar URL builder ───────────────────────────────────────────
+
+/**
+ * Builds a Google Calendar "Add to Calendar" URL for a single event.
+ */
+export function buildGoogleCalendarUrl(event: CalendarEvent): string {
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.summary,
+    dates: `${formatICalDate(event.dtstart)}/${formatICalDate(event.dtend)}`,
+    details: event.description,
+    ...(event.location ? { location: event.location } : {}),
+  })
+  return `https://calendar.google.com/calendar/render?${params.toString()}`
+}
+
+/**
+ * Builds an Outlook Web "Add to Calendar" URL for a single event.
+ */
+export function buildOutlookCalendarUrl(event: CalendarEvent): string {
+  const params = new URLSearchParams({
+    path: '/calendar/action/compose',
+    rru: 'addevent',
+    subject: event.summary,
+    startdt: event.dtstart.toISOString(),
+    enddt: event.dtend.toISOString(),
+    body: event.description,
+    ...(event.location ? { location: event.location } : {}),
+  })
+  return `https://outlook.live.com/calendar/0/deeplink/compose?${params.toString()}`
+}
+
+// ── Domain-specific event builders ───────────────────────────────────────
+
+export interface ContributionReminderEventOptions {
+  groupId: string
+  groupName: string
+  contributionAmount: string
+  dueDate: Date
+  cycleNumber: number
+  appUrl?: string
+}
+
+/**
+ * Builds a CalendarEvent for a contribution reminder.
+ */
+export function buildContributionReminderEvent(
+  opts: ContributionReminderEventOptions
+): CalendarEvent {
+  const dtend = new Date(opts.dueDate.getTime() + 60 * 60 * 1000) // 1 hour window
+  return {
+    uid: `contribution-${opts.groupId}-cycle${opts.cycleNumber}-${generateUID()}`,
+    summary: `Contribution Due — ${opts.groupName}`,
+    description: `Your contribution of ${opts.contributionAmount} for cycle #${opts.cycleNumber} in "${opts.groupName}" is due. Pay on time to maintain your standing.`,
+    dtstart: opts.dueDate,
+    dtend,
+    url: opts.appUrl,
+    alarmMinutes: 60, // 1 hour before
+  }
+}
+
+export interface PayoutEventOptions {
+  groupId: string
+  groupName: string
+  payoutAmount: string
+  payoutDate: Date
+  appUrl?: string
+}
+
+/**
+ * Builds a CalendarEvent for an upcoming payout.
+ */
+export function buildPayoutEvent(opts: PayoutEventOptions): CalendarEvent {
+  const dtend = new Date(opts.payoutDate.getTime() + 60 * 60 * 1000)
+  return {
+    uid: `payout-${opts.groupId}-${generateUID()}`,
+    summary: `Payout Incoming — ${opts.groupName}`,
+    description: `You are scheduled to receive ${opts.payoutAmount} from "${opts.groupName}".`,
+    dtstart: opts.payoutDate,
+    dtend,
+    url: opts.appUrl,
+    alarmMinutes: 120, // 2 hours before
+  }
+}
+
+// ── Group calendar generation ─────────────────────────────────────────────
+
+/**
+ * Generates a full iCal feed for all upcoming contribution deadlines
+ * and payouts for a given user across all their groups.
+ */
+export async function generateUserCalendarFeed(userId: string): Promise<string> {
+  const appUrl = process.env.FRONTEND_URL ?? 'https://app.ajo.finance'
+  const events: CalendarEvent[] = []
+
+  const memberships = await prisma.groupMember.findMany({
+    where: { userId },
+    include: {
+      group: {
+        include: {
+          contributions: {
+            where: { userId },
+            orderBy: { createdAt: 'desc' },
+            take: 1,
+          },
+        },
+      },
+    },
+  })
+
+  for (const membership of memberships) {
+    const group = membership.group as any
+    if (!group.isActive) continue
+
+    const deadline: Date | undefined = group.cycleDeadline ?? group.nextPayoutAt
+    if (deadline && deadline > new Date()) {
+      const amount = `${Number(group.contributionAmount) / 1e7} XLM`
+      events.push(
+        buildContributionReminderEvent({
+          groupId: group.id,
+          groupName: group.name,
+          contributionAmount: amount,
+          dueDate: deadline,
+          cycleNumber: group.currentRound ?? 1,
+          appUrl: `${appUrl}/groups/${group.id}`,
+        })
+      )
+    }
+  }
+
+  logger.info(`Generated calendar feed for user ${userId}: ${events.length} events`)
+  return buildICalendar(events, 'Ajo — My Contributions')
+}
+
+/**
+ * Generates a single-event iCal for a specific contribution reminder.
+ */
+export async function generateContributionEventIcal(
+  groupId: string,
+  userId: string
+): Promise<{ ical: string; googleUrl: string; outlookUrl: string } | null> {
+  const appUrl = process.env.FRONTEND_URL ?? 'https://app.ajo.finance'
+
+  const group = await prisma.group.findUnique({
+    where: { id: groupId },
+  }) as any
+
+  if (!group) return null
+
+  const deadline: Date | undefined = group.cycleDeadline ?? group.nextPayoutAt
+  if (!deadline) return null
+
+  const amount = `${Number(group.contributionAmount) / 1e7} XLM`
+  const event = buildContributionReminderEvent({
+    groupId: group.id,
+    groupName: group.name,
+    contributionAmount: amount,
+    dueDate: deadline,
+    cycleNumber: group.currentRound ?? 1,
+    appUrl: `${appUrl}/groups/${group.id}`,
+  })
+
+  return {
+    ical: buildICalendar([event]),
+    googleUrl: buildGoogleCalendarUrl(event),
+    outlookUrl: buildOutlookCalendarUrl(event),
+  }
+}

--- a/frontend/src/components/reminders/AddToCalendarButton.tsx
+++ b/frontend/src/components/reminders/AddToCalendarButton.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+/**
+ * AddToCalendarButton — Issue #619
+ *
+ * Dropdown button for adding a contribution reminder or payout event
+ * to Google Calendar, Outlook, or downloading as .ics.
+ */
+
+import React, { useState, useRef, useEffect } from 'react';
+import { Calendar, ChevronDown, Download, ExternalLink } from 'lucide-react';
+import {
+  useCalendarIntegration,
+  type CalendarEventOptions,
+  type CalendarProvider,
+} from '@/hooks/useCalendarIntegration';
+
+interface Props extends CalendarEventOptions {
+  label?: string;
+  className?: string;
+}
+
+const PROVIDERS: { id: CalendarProvider; label: string; icon: React.ReactNode }[] = [
+  {
+    id: 'google',
+    label: 'Google Calendar',
+    icon: <ExternalLink className="w-3.5 h-3.5" />,
+  },
+  {
+    id: 'outlook',
+    label: 'Outlook',
+    icon: <ExternalLink className="w-3.5 h-3.5" />,
+  },
+  {
+    id: 'ics',
+    label: 'Download .ics',
+    icon: <Download className="w-3.5 h-3.5" />,
+  },
+];
+
+export function AddToCalendarButton({ label = 'Add to Calendar', className, ...eventOpts }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const { addToCalendar, isLoading, error } = useCalendarIntegration();
+
+  // Close on outside click
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const handleSelect = async (provider: CalendarProvider) => {
+    setOpen(false);
+    await addToCalendar(eventOpts, provider);
+  };
+
+  return (
+    <div ref={ref} className={`relative inline-block ${className ?? ''}`}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        disabled={isLoading}
+        className="flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-lg border border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-700 disabled:opacity-50 transition-colors"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <Calendar className="w-4 h-4 text-indigo-500" />
+        {isLoading ? 'Adding…' : label}
+        <ChevronDown className={`w-3.5 h-3.5 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          className="absolute z-50 mt-1 w-48 rounded-xl border border-gray-200 dark:border-slate-600 bg-white dark:bg-slate-800 shadow-lg overflow-hidden"
+        >
+          {PROVIDERS.map((p) => (
+            <button
+              key={p.id}
+              role="option"
+              onClick={() => handleSelect(p.id)}
+              className="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-slate-200 hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors"
+            >
+              {p.icon}
+              {p.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <p className="absolute top-full mt-1 text-xs text-red-500 whitespace-nowrap">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/reminders/CalendarSubscribeButton.tsx
+++ b/frontend/src/components/reminders/CalendarSubscribeButton.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+/**
+ * CalendarSubscribeButton — Issue #619
+ *
+ * Button to subscribe to the user's personal Ajo iCal feed,
+ * which auto-syncs all upcoming contribution and payout events.
+ */
+
+import React from 'react';
+import { CalendarDays } from 'lucide-react';
+import { useCalendarIntegration } from '@/hooks/useCalendarIntegration';
+
+interface Props {
+  className?: string;
+}
+
+export function CalendarSubscribeButton({ className }: Props) {
+  const { subscribeToFeed } = useCalendarIntegration();
+
+  return (
+    <button
+      onClick={subscribeToFeed}
+      className={`flex items-center gap-2 text-sm px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white transition-colors ${className ?? ''}`}
+    >
+      <CalendarDays className="w-4 h-4" />
+      Subscribe to Calendar
+    </button>
+  );
+}

--- a/frontend/src/hooks/useCalendarIntegration.ts
+++ b/frontend/src/hooks/useCalendarIntegration.ts
@@ -1,0 +1,98 @@
+'use client';
+
+/**
+ * useCalendarIntegration — Issue #619
+ *
+ * Hook for adding contribution reminders and payout events to
+ * Google Calendar, Outlook, or downloading as .ics files.
+ */
+
+import { useCallback, useState } from 'react';
+
+export type CalendarProvider = 'google' | 'outlook' | 'ics';
+
+export interface CalendarEventOptions {
+  groupId: string;
+  groupName: string;
+  amount: string;
+  date: Date;
+  type: 'contribution' | 'payout';
+  cycleNumber?: number;
+}
+
+interface UseCalendarIntegrationReturn {
+  addToCalendar: (opts: CalendarEventOptions, provider: CalendarProvider) => Promise<void>;
+  subscribeToFeed: () => void;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
+
+export function useCalendarIntegration(): UseCalendarIntegrationReturn {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addToCalendar = useCallback(
+    async (opts: CalendarEventOptions, provider: CalendarProvider) => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        if (provider === 'ics') {
+          // Download .ics file directly
+          const res = await fetch(
+            `${API_BASE}/api/calendar/groups/${opts.groupId}/event?format=ics`,
+            { credentials: 'include' }
+          );
+          if (!res.ok) throw new Error('Failed to generate calendar event');
+          const blob = await res.blob();
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = `contribution-${opts.groupId}.ics`;
+          a.click();
+          URL.revokeObjectURL(url);
+          return;
+        }
+
+        // Get calendar URLs from backend
+        const res = await fetch(`${API_BASE}/api/calendar/events/custom`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            type: opts.type,
+            groupId: opts.groupId,
+            groupName: opts.groupName,
+            amount: opts.amount,
+            date: opts.date.toISOString(),
+            cycleNumber: opts.cycleNumber,
+          }),
+        });
+
+        if (!res.ok) throw new Error('Failed to generate calendar links');
+        const data = await res.json();
+
+        const url =
+          provider === 'google' ? data.googleCalendarUrl : data.outlookCalendarUrl;
+        window.open(url, '_blank', 'noopener,noreferrer');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Calendar integration failed');
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    []
+  );
+
+  const subscribeToFeed = useCallback(() => {
+    // Opens the iCal feed URL — calendar apps can subscribe to this
+    const feedUrl = `${API_BASE}/api/calendar/feed`;
+    // Try webcal:// protocol for native calendar app subscription
+    const webcalUrl = feedUrl.replace(/^https?:\/\//, 'webcal://');
+    window.open(webcalUrl, '_blank', 'noopener,noreferrer');
+  }, []);
+
+  return { addToCalendar, subscribeToFeed, isLoading, error };
+}


### PR DESCRIPTION
…n reminders

- Add calendarService: iCal (.ics) generation, Google Calendar URL builder, Outlook Web URL builder, and per-user calendar feed generation
- Add /api/calendar/feed endpoint: subscribable iCal feed for all user events
- Add /api/calendar/groups/:groupId/event: single-event .ics download or JSON links
- Add /api/calendar/events/custom: generate calendar links for custom events
- Add useCalendarIntegration hook: addToCalendar (google/outlook/ics) and subscribeToFeed
- Add AddToCalendarButton component: dropdown with Google, Outlook, and .ics options
- Add CalendarSubscribeButton component: one-click webcal:// feed subscription
- Register calendar routes in backend index

Closes #619