### PR TITLE
feat: implement democratic payout voting for group cycles

### DIFF
--- a/backend/src/services/votingService.ts
+++ b/backend/src/services/votingService.ts
@@ -1,0 +1,64 @@
+export interface VoteRecord {
+  groupId: string;
+  cycle: number;
+  voter: string;
+  candidate: string;
+  timestamp: number;
+}
+
+export interface VoteTally {
+  candidate: string;
+  votes: number;
+}
+
+export class VotingService {
+  /** votes[groupId][cycle][voter] = candidate */
+  private votes: Map<string, Map<number, Map<string, string>>> = new Map();
+
+  private cycleKey(groupId: string, cycle: number) {
+    return `${groupId}:${cycle}`;
+  }
+
+  castVote(groupId: string, cycle: number, voter: string, candidate: string): VoteRecord {
+    if (!this.votes.has(groupId)) this.votes.set(groupId, new Map());
+    const byCycle = this.votes.get(groupId)!;
+    if (!byCycle.has(cycle)) byCycle.set(cycle, new Map());
+    const byVoter = byCycle.get(cycle)!;
+
+    if (byVoter.has(voter)) {
+      throw new Error('Member has already voted this cycle');
+    }
+
+    byVoter.set(voter, candidate);
+    return { groupId, cycle, voter, candidate, timestamp: Date.now() };
+  }
+
+  getTally(groupId: string, cycle: number): VoteTally[] {
+    const byVoter = this.votes.get(groupId)?.get(cycle);
+    if (!byVoter) return [];
+
+    const counts = new Map<string, number>();
+    for (const candidate of byVoter.values()) {
+      counts.set(candidate, (counts.get(candidate) ?? 0) + 1);
+    }
+
+    return Array.from(counts.entries())
+      .map(([candidate, votes]) => ({ candidate, votes }))
+      .sort((a, b) => b.votes - a.votes);
+  }
+
+  getWinner(groupId: string, cycle: number): string | null {
+    const tally = this.getTally(groupId, cycle);
+    return tally.length > 0 ? tally[0].candidate : null;
+  }
+
+  hasVoted(groupId: string, cycle: number, voter: string): boolean {
+    return this.votes.get(groupId)?.get(cycle)?.has(voter) ?? false;
+  }
+
+  getVoteCount(groupId: string, cycle: number): number {
+    return this.votes.get(groupId)?.get(cycle)?.size ?? 0;
+  }
+}
+
+export const votingService = new VotingService();

--- a/contracts/ajo/src/lib.rs
+++ b/contracts/ajo/src/lib.rs
@@ -25,6 +25,7 @@ mod utils;
 mod insurance;
 mod loan;
 mod emergency;
+pub mod voting;
 
 pub use contract::AjoContract;
 pub use contract::AjoContractClient;

--- a/contracts/ajo/src/voting.rs
+++ b/contracts/ajo/src/voting.rs
@@ -1,0 +1,112 @@
+use soroban_sdk::{contracttype, Address, Env, Vec, symbol_short, Symbol};
+
+/// A single vote cast by a member for a candidate payout recipient.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PayoutVoteCast {
+    pub group_id: u64,
+    pub cycle: u32,
+    pub voter: Address,
+    pub candidate: Address,
+    pub timestamp: u64,
+}
+
+/// Aggregated tally for one candidate in a cycle.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VoteTally {
+    pub candidate: Address,
+    pub votes: u32,
+}
+
+const VOTE_KEY: Symbol = symbol_short!("PVOTE");
+const TALLY_KEY: Symbol = symbol_short!("PTALLY");
+const VOTED_KEY: Symbol = symbol_short!("PVOTED");
+
+fn vote_key(env: &Env, group_id: u64, cycle: u32, voter: &Address) -> soroban_sdk::Val {
+    (VOTE_KEY, group_id, cycle, voter.clone()).into_val(env)
+}
+
+fn tally_key(env: &Env, group_id: u64, cycle: u32, candidate: &Address) -> soroban_sdk::Val {
+    (TALLY_KEY, group_id, cycle, candidate.clone()).into_val(env)
+}
+
+fn voted_key(env: &Env, group_id: u64, cycle: u32, voter: &Address) -> soroban_sdk::Val {
+    (VOTED_KEY, group_id, cycle, voter.clone()).into_val(env)
+}
+
+/// Cast a vote for a payout candidate in the current cycle.
+/// Each member may vote once per cycle.
+pub fn cast_vote(
+    env: &Env,
+    group_id: u64,
+    cycle: u32,
+    voter: Address,
+    candidate: Address,
+    members: &Vec<Address>,
+) {
+    voter.require_auth();
+
+    assert!(members.contains(&voter), "voter is not a group member");
+    assert!(members.contains(&candidate), "candidate is not a group member");
+
+    let vk = voted_key(env, group_id, cycle, &voter);
+    let already: bool = env.storage().instance().get(&vk).unwrap_or(false);
+    assert!(!already, "already voted this cycle");
+
+    let vote = PayoutVoteCast {
+        group_id,
+        cycle,
+        voter: voter.clone(),
+        candidate: candidate.clone(),
+        timestamp: env.ledger().timestamp(),
+    };
+
+    env.storage().instance().set(&vote_key(env, group_id, cycle, &voter), &vote);
+    env.storage().instance().set(&vk, &true);
+
+    // Increment tally
+    let tk = tally_key(env, group_id, cycle, &candidate);
+    let current: u32 = env.storage().instance().get(&tk).unwrap_or(0u32);
+    env.storage().instance().set(&tk, &(current + 1));
+}
+
+/// Get the vote tally for a specific candidate in a cycle.
+pub fn get_tally(env: &Env, group_id: u64, cycle: u32, candidate: &Address) -> u32 {
+    env.storage()
+        .instance()
+        .get(&tally_key(env, group_id, cycle, candidate))
+        .unwrap_or(0u32)
+}
+
+/// Determine the winner (most votes) among a list of candidates.
+/// Returns None if no votes have been cast.
+pub fn get_winner(
+    env: &Env,
+    group_id: u64,
+    cycle: u32,
+    candidates: &Vec<Address>,
+) -> Option<Address> {
+    let mut best: Option<(Address, u32)> = None;
+    for candidate in candidates.iter() {
+        let votes = get_tally(env, group_id, cycle, &candidate);
+        if votes > 0 {
+            match &best {
+                None => best = Some((candidate, votes)),
+                Some((_, best_votes)) if votes > *best_votes => {
+                    best = Some((candidate, votes));
+                }
+                _ => {}
+            }
+        }
+    }
+    best.map(|(addr, _)| addr)
+}
+
+/// Check whether a member has already voted in a cycle.
+pub fn has_voted(env: &Env, group_id: u64, cycle: u32, voter: &Address) -> bool {
+    env.storage()
+        .instance()
+        .get(&voted_key(env, group_id, cycle, voter))
+        .unwrap_or(false)
+}

--- a/frontend/src/components/PayoutVoting.tsx
+++ b/frontend/src/components/PayoutVoting.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+
+interface Member {
+  address: string;
+  name?: string;
+}
+
+interface VoteTally {
+  candidate: string;
+  votes: number;
+}
+
+interface PayoutVotingProps {
+  groupId: string;
+  cycle: number;
+  members: Member[];
+  currentUser: string;
+  apiUrl: string;
+  /** Dispute window in seconds after voting closes */
+  disputeWindowSeconds?: number;
+}
+
+export default function PayoutVoting({
+  groupId,
+  cycle,
+  members,
+  currentUser,
+  apiUrl,
+  disputeWindowSeconds = 3600,
+}: PayoutVotingProps) {
+  const [tally, setTally] = useState<VoteTally[]>([]);
+  const [hasVoted, setHasVoted] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string>('');
+
+  useEffect(() => {
+    fetchTally();
+    checkVoted();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupId, cycle]);
+
+  async function fetchTally() {
+    try {
+      const res = await fetch(`${apiUrl}/voting/${groupId}/${cycle}/tally`);
+      if (res.ok) setTally(await res.json());
+    } catch {
+      // non-fatal
+    }
+  }
+
+  async function checkVoted() {
+    try {
+      const res = await fetch(
+        `${apiUrl}/voting/${groupId}/${cycle}/voted?voter=${currentUser}`
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setHasVoted(data.hasVoted);
+      }
+    } catch {
+      // non-fatal
+    }
+  }
+
+  async function handleVote() {
+    if (!selected) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${apiUrl}/voting/${groupId}/${cycle}/vote`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ voter: currentUser, candidate: selected }),
+      });
+      if (!res.ok) throw new Error((await res.json()).error ?? 'Vote failed');
+      setHasVoted(true);
+      await fetchTally();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const totalVotes = tally.reduce((s, t) => s + t.votes, 0);
+  const winner = tally[0];
+
+  return (
+    <div className="space-y-5">
+      <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <h3 className="mb-1 text-base font-semibold text-gray-900 dark:text-white">
+          Payout Vote — Cycle {cycle}
+        </h3>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Vote for who should receive the payout this cycle. Results are transparent and on-chain.
+        </p>
+      </div>
+
+      {/* Voting form */}
+      {!hasVoted ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <p className="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300">
+            Select a member to receive the payout:
+          </p>
+          <div className="space-y-2">
+            {members.map((m) => (
+              <label
+                key={m.address}
+                className="flex cursor-pointer items-center gap-3 rounded-lg border border-gray-200 p-3 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-700"
+              >
+                <input
+                  type="radio"
+                  name="candidate"
+                  value={m.address}
+                  checked={selected === m.address}
+                  onChange={() => setSelected(m.address)}
+                  className="accent-blue-600"
+                />
+                <span className="text-sm text-gray-800 dark:text-gray-200">
+                  {m.name ?? m.address.slice(0, 12) + '…'}
+                </span>
+              </label>
+            ))}
+          </div>
+
+          {error && <p className="mt-2 text-xs text-red-600 dark:text-red-400">{error}</p>}
+
+          <button
+            onClick={handleVote}
+            disabled={!selected || loading}
+            className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? 'Submitting…' : 'Cast Vote'}
+          </button>
+        </div>
+      ) : (
+        <p className="rounded-xl border border-green-200 bg-green-50 p-4 text-sm text-green-700 dark:border-green-800 dark:bg-green-900/20 dark:text-green-400">
+          ✓ Your vote has been recorded.
+        </p>
+      )}
+
+      {/* Live tally */}
+      {tally.length > 0 && (
+        <div className="rounded-xl border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <h4 className="mb-3 text-sm font-semibold text-gray-900 dark:text-white">
+            Live Results ({totalVotes} vote{totalVotes !== 1 ? 's' : ''})
+          </h4>
+          <ul className="space-y-2">
+            {tally.map((t) => {
+              const pct = totalVotes > 0 ? Math.round((t.votes / totalVotes) * 100) : 0;
+              const isWinner = t.candidate === winner?.candidate;
+              return (
+                <li key={t.candidate}>
+                  <div className="mb-0.5 flex justify-between text-xs text-gray-600 dark:text-gray-400">
+                    <span className={isWinner ? 'font-semibold text-blue-600 dark:text-blue-400' : ''}>
+                      {t.candidate.slice(0, 12)}…{isWinner ? ' 🏆' : ''}
+                    </span>
+                    <span>{t.votes} ({pct}%)</span>
+                  </div>
+                  <div className="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700">
+                    <div
+                      className={`h-full rounded-full transition-all ${isWinner ? 'bg-blue-500' : 'bg-gray-400'}`}
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+          <p className="mt-3 text-xs text-gray-400 dark:text-gray-500">
+            Dispute window: {disputeWindowSeconds / 60} min after voting closes.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
- Add contracts/ajo/src/voting.rs with on-chain vote casting, tally, and winner selection
- One vote per member per cycle, transparent results stored on-chain
- Add backend/src/services/votingService.ts for vote aggregation and tally queries
- Add frontend/src/components/PayoutVoting.tsx with live results and dispute window display

Closes #769