### PR TITLE
fix: de-duplicate root/[locale] layout tree breaking desktop scroll

### DIFF
--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -1,16 +1,13 @@
-import { NextIntlClientProvider } from 'next-intl';
-import { getMessages } from 'next-intl/server';
-import { notFound } from 'next/navigation';
-import type { Metadata, Viewport } from 'next';
-import { Inter } from 'next/font/google';
-import '../../styles/globals.css';
-import { Providers } from '../providers';
-import { AppLayout } from '@/components/AppLayout';
-import { InstallPrompt } from '@/components/InstallPrompt';
-import { OfflineIndicator } from '@/components/OfflineIndicator';
-import { locales } from '@/i18n';
-
-const inter = Inter({ subsets: ['latin'] });
+import { NextIntlClientProvider } from 'next-intl'
+import { getMessages } from 'next-intl/server'
+import { notFound } from 'next/navigation'
+import type { Metadata, Viewport } from 'next'
+import { Providers } from '../providers'
+import { AppLayout } from '@/components/AppLayout'
+import { InstallPrompt } from '@/components/InstallPrompt'
+import { OfflineIndicator } from '@/components/OfflineIndicator'
+import { OnboardingFlow } from '@/components/onboarding'
+import { locales } from '@/i18n'
 
 export const metadata: Metadata = {
   title: 'Ajo - Decentralized Savings Groups',
@@ -54,7 +51,7 @@ export const metadata: Metadata = {
     statusBarStyle: 'default',
     title: 'Ajo',
   },
-};
+}
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -65,45 +62,40 @@ export const viewport: Viewport = {
     { media: '(prefers-color-scheme: light)', color: '#3b82f6' },
     { media: '(prefers-color-scheme: dark)', color: '#1e40af' },
   ],
-};
+}
 
 export function generateStaticParams() {
-  return locales.map((locale) => ({ locale }));
+  return locales.map((locale) => ({ locale }))
 }
 
 export default async function LocaleLayout({
   children,
-  params: { locale }
+  params: { locale },
 }: {
-  children: React.ReactNode;
-  params: { locale: string };
+  children: React.ReactNode
+  params: { locale: string }
 }) {
   if (!locales.includes(locale as any)) {
-    notFound();
+    notFound()
   }
 
-  const messages = await getMessages();
+  const messages = await getMessages()
 
+  // NOTE: no <html>/<body> here — the root layout (src/app/layout.tsx) is
+  // the only place those may appear. This layout is always nested inside
+  // it (middleware redirects every request to a /[locale]/* path), so
+  // rendering a second <html>/<body> here would produce invalid nested
+  // document elements and double-mount every provider/app-shell component
+  // below (wallet connections, sidebar, etc. twice) — this previously broke
+  // the page's scroll/layout on desktop.
   return (
-    <html lang={locale}>
-      <head>
-        <link rel="manifest" href="/manifest.json" />
-        <meta name="mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-        <meta name="apple-mobile-web-app-title" content="Ajo" />
-      </head>
-      <body className={inter.className}>
-        <div className="pattern-overlay gradient-mesh min-h-screen">
-          <NextIntlClientProvider messages={messages}>
-            <Providers>
-              <AppLayout>{children}</AppLayout>
-              <InstallPrompt />
-              <OfflineIndicator />
-            </Providers>
-          </NextIntlClientProvider>
-        </div>
-      </body>
-    </html>
-  );
+    <NextIntlClientProvider messages={messages}>
+      <Providers>
+        <AppLayout>{children}</AppLayout>
+        <OnboardingFlow />
+        <InstallPrompt />
+        <OfflineIndicator />
+      </Providers>
+    </NextIntlClientProvider>
+  )
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,12 +1,8 @@
 import type { Metadata, Viewport } from 'next'
 import { Inter } from 'next/font/google'
 import Script from 'next/script'
+import { getLocale } from 'next-intl/server'
 import '../styles/globals.css'
-import { Providers } from './providers'
-import { AppLayout } from '@/components/AppLayout'
-import { InstallPrompt } from '@/components/InstallPrompt'
-import { OfflineIndicator } from '@/components/OfflineIndicator'
-import { OnboardingFlow } from '@/components/onboarding'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -67,9 +63,17 @@ export const viewport: Viewport = {
   ],
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  // This is the only layout allowed to render <html>/<body> — every real
+  // request is redirected by middleware to a /[locale]/* path, and
+  // src/app/[locale]/layout.tsx (nested inside this one) owns the actual
+  // app shell (providers, sidebar/nav, etc.). Duplicating <html>/<body> or
+  // the app shell here previously double-mounted everything and broke
+  // desktop scrolling.
+  const locale = await getLocale()
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
         <link rel="manifest" href="/manifest.json" />
         <meta name="mobile-web-app-capable" content="yes" />
@@ -107,14 +111,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             `}</Script>
           </>
         )}
-        <div className="pattern-overlay gradient-mesh min-h-screen">
-          <Providers>
-            <AppLayout>{children}</AppLayout>
-            <OnboardingFlow />
-            <InstallPrompt />
-            <OfflineIndicator />
-          </Providers>
-        </div>
+        <div className="pattern-overlay gradient-mesh min-h-screen">{children}</div>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary

Fixes the "not PC friendly / scrollbar not showing" report on production.

`src/app/layout.tsx` (root) and `src/app/[locale]/layout.tsx` (nested) both rendered their own `<html>`/`<body>` and independently mounted the entire app shell — `Providers`, `AppLayout` (desktop `FloatingSidebar` / mobile nav), `OnboardingFlow`, `InstallPrompt`, `OfflineIndicator` — each wrapped in its own `pattern-overlay gradient-mesh min-h-screen` div.

Since middleware redirects every real request to a `/[locale]/*` path, and Next.js always nests a route's layout inside its parent, **every single page shipped two invalid, nested `<html><body>` trees with the whole app shell double-mounted inside.** Two nested `min-h-screen` containers plus a fixed-position sidebar rendered twice collapses the browser's normal scroll calculation — that's why the real page scrollbar never appeared on desktop. It also meant wallet/websocket providers and onboarding logic were initializing twice on every page load.

## Fix
- Only the root layout renders `<html>`/`<body>` now, using next-intl's `getLocale()` for the `lang` attribute (root sits above the `[locale]` segment and has no route param access).
- `[locale]/layout.tsx` no longer renders `<html>`/`<body>` — it returns the `NextIntlClientProvider`-wrapped app shell directly, which nests correctly inside the root's `<body>`.
- Moved `OnboardingFlow` (previously only mounted via the now-removed root app-shell block) into the `[locale]` layout so the feature isn't lost.

## Test plan
- [x] `next build` succeeds; `/[locale]/*` routes remain statically generated (only the already-unreachable non-locale duplicate routes flipped from static to dynamic, which doesn't matter since middleware redirects away from them anyway)
- [x] `next start` + curled `/en/dashboard`: exactly one `<html>` tag, one `<body>` tag, one sidebar/nav mount, `lang="en"` resolves correctly
