### PR TITLE
fix: make wallet-selection modal scrollable

### DIFF
--- a/frontend/src/components/WalletConnector.tsx
+++ b/frontend/src/components/WalletConnector.tsx
@@ -74,8 +74,8 @@ export const WalletConnector: React.FC = () => {
         icon: '⭐',
         description: 'Web-based wallet',
       },
-    ];
-  }, [walletDetection]);
+    ]
+  }, [walletDetection])
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -178,7 +178,7 @@ export const WalletConnector: React.FC = () => {
                 setShowWalletSelection(false)
               }}
             />
-            <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-800 rounded-xl shadow-2xl p-6 w-full max-w-md z-50">
+            <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-800 rounded-xl shadow-2xl p-6 w-full max-w-md max-h-[85vh] overflow-y-auto z-50">
               <div className="flex items-center justify-between mb-6">
                 <h3 className="text-xl font-bold text-gray-900 dark:text-white">
                   {pendingTwoFactor ? 'Enter authentication code' : 'Select Wallet'}
@@ -248,10 +248,11 @@ export const WalletConnector: React.FC = () => {
                         key={wallet.provider}
                         onClick={() => handleConnect(wallet.provider)}
                         disabled={!wallet.isInstalled}
-                        className={`w-full p-4 rounded-lg border-2 transition-all text-left ${wallet.isInstalled
+                        className={`w-full p-4 rounded-lg border-2 transition-all text-left ${
+                          wallet.isInstalled
                             ? 'border-gray-200 hover:border-blue-500 hover:bg-blue-50 dark:border-gray-700 dark:hover:border-blue-500 dark:hover:bg-blue-900/20 cursor-pointer'
                             : 'border-gray-100 bg-gray-50 dark:border-gray-800 dark:bg-gray-900 cursor-not-allowed opacity-60'
-                          }`}
+                        }`}
                       >
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-3">
@@ -390,10 +391,11 @@ export const WalletConnector: React.FC = () => {
                 <button
                   key={tab}
                   onClick={() => setActiveTab(tab)}
-                  className={`flex-1 py-2.5 text-xs font-semibold uppercase tracking-wider transition-colors ${activeTab === tab
+                  className={`flex-1 py-2.5 text-xs font-semibold uppercase tracking-wider transition-colors ${
+                    activeTab === tab
                       ? 'text-blue-600 border-b-2 border-blue-600 -mb-px bg-blue-50/30'
                       : 'text-gray-400 hover:text-gray-600'
-                    }`}
+                  }`}
                 >
                   {tab}
                 </button>

--- a/frontend/src/components/WalletModal.tsx
+++ b/frontend/src/components/WalletModal.tsx
@@ -1,24 +1,20 @@
-'use client';
+'use client'
 
-import React, { useEffect, useCallback, useState, useRef, memo } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import Image from 'next/image';
-import { useWallet } from '../hooks/useWallet';
-import { WalletCard } from './wallet/WalletCard';
-import { ConnectionStatus, ConnectionState } from './wallet/ConnectionStatus';
-import {
-  backdropVariants,
-  modalVariants,
-  walletListVariants,
-} from '../animations/walletAnimations';
-import type { WalletType, WalletInfo } from '../types/wallet';
+import React, { useEffect, useCallback, useState, useRef, memo } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import Image from 'next/image'
+import { useWallet } from '../hooks/useWallet'
+import { WalletCard } from './wallet/WalletCard'
+import { ConnectionStatus, ConnectionState } from './wallet/ConnectionStatus'
+import { backdropVariants, modalVariants, walletListVariants } from '../animations/walletAnimations'
+import type { WalletType, WalletInfo } from '../types/wallet'
 
 interface WalletModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onConnect?: (address: string) => void;
-  onError?: (error: string) => void;
-  showNetworkSelector?: boolean;
+  isOpen: boolean
+  onClose: () => void
+  onConnect?: (address: string) => void
+  onError?: (error: string) => void
+  showNetworkSelector?: boolean
 }
 
 /**
@@ -27,142 +23,146 @@ interface WalletModalProps {
  *
  * Supports Freighter and Lobstr wallets with installation status detection.
  */
-export const WalletModal: React.FC<WalletModalProps> = memo(({
-  isOpen,
-  onClose,
-  onConnect,
-  onError,
-  showNetworkSelector = false,
-}) => {
-  const {
-    isLoading,
-    error,
-    availableWallets,
-    connect,
-  } = useWallet();
+export const WalletModal: React.FC<WalletModalProps> = memo(
+  ({ isOpen, onClose, onConnect, onError, showNetworkSelector = false }) => {
+    const { isLoading, error, availableWallets, connect } = useWallet()
 
-  const [connectionState, setConnectionState] = useState<ConnectionState>('idle');
-  const [statusMessage, setStatusMessage] = useState('');
-  const [selectedWallet, setSelectedWallet] = useState<WalletType | null>(null);
-  const [selectedNetwork, setSelectedNetwork] = useState<'testnet' | 'mainnet' | 'futurenet'>('testnet');
-  const previousFocusRef = useRef<HTMLElement | null>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
+    const [connectionState, setConnectionState] = useState<ConnectionState>('idle')
+    const [statusMessage, setStatusMessage] = useState('')
+    const [selectedWallet, setSelectedWallet] = useState<WalletType | null>(null)
+    const [selectedNetwork, setSelectedNetwork] = useState<'testnet' | 'mainnet' | 'futurenet'>(
+      'testnet'
+    )
+    const previousFocusRef = useRef<HTMLElement | null>(null)
+    const panelRef = useRef<HTMLDivElement>(null)
 
-  // Reset state when modal opens
-  useEffect(() => {
-    if (isOpen) {
-      previousFocusRef.current = document.activeElement as HTMLElement;
-      setConnectionState('idle');
-      setStatusMessage('');
-      setSelectedWallet(null);
-      setTimeout(() => panelRef.current?.focus(), 0);
-    } else {
-      previousFocusRef.current?.focus();
-    }
-  }, [isOpen]);
-
-  // Keyboard: ESC to close
-  const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      onClose();
-    }
-  }, [onClose]);
-
-  useEffect(() => {
-    if (isOpen) {
-      document.addEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = 'hidden';
-    }
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-      document.body.style.overflow = '';
-    };
-  }, [isOpen, handleKeyDown]);
-
-  // Focus trap
-  useEffect(() => {
-    if (!isOpen || !panelRef.current) return;
-    const panel = panelRef.current;
-    const focusableSelectors =
-      'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
-    const handleTab = (e: KeyboardEvent) => {
-      if (e.key !== 'Tab') return;
-      const focusables = Array.from(panel.querySelectorAll<HTMLElement>(focusableSelectors));
-      if (!focusables.length) return;
-      const first = focusables[0];
-      const last = focusables[focusables.length - 1];
-      if (e.shiftKey) {
-        if (document.activeElement === first) { last.focus(); e.preventDefault(); }
+    // Reset state when modal opens
+    useEffect(() => {
+      if (isOpen) {
+        previousFocusRef.current = document.activeElement as HTMLElement
+        setConnectionState('idle')
+        setStatusMessage('')
+        setSelectedWallet(null)
+        setTimeout(() => panelRef.current?.focus(), 0)
       } else {
-        if (document.activeElement === last) { first.focus(); e.preventDefault(); }
+        previousFocusRef.current?.focus()
       }
-    };
-    panel.addEventListener('keydown', handleTab);
-    return () => panel.removeEventListener('keydown', handleTab);
-  }, [isOpen]);
+    }, [isOpen])
 
-  const handleWalletSelect = useCallback(async (walletType: WalletType) => {
-    setSelectedWallet(walletType);
-    setConnectionState('connecting');
-    setStatusMessage('Connecting to wallet...');
+    // Keyboard: ESC to close
+    const handleKeyDown = useCallback(
+      (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          onClose()
+        }
+      },
+      [onClose]
+    )
 
-    const result = await connect({
-      walletType,
-      network: selectedNetwork,
-    });
-
-    if (result.success) {
-      setConnectionState('success');
-      setStatusMessage('Connected successfully');
-      if (result.address && onConnect) {
-        onConnect(result.address);
+    useEffect(() => {
+      if (isOpen) {
+        document.addEventListener('keydown', handleKeyDown)
+        document.body.style.overflow = 'hidden'
       }
-      // Auto-close after success
-      setTimeout(() => onClose(), 1200);
-    } else {
-      setConnectionState('error');
-      const msg = result.error?.message || 'Connection failed. Please try again.';
-      setStatusMessage(msg);
-      if (onError && result.error) {
-        onError(result.error.message);
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown)
+        document.body.style.overflow = ''
       }
-    }
-  }, [connect, selectedNetwork, onConnect, onError, onClose]);
+    }, [isOpen, handleKeyDown])
 
-  // Filter to Freighter and Lobstr only (per issue requirements)
-  const supportedWallets = availableWallets.filter(
-    (w: WalletInfo) => w.type === 'freighter' || w.type === 'lobstr'
-  );
+    // Focus trap
+    useEffect(() => {
+      if (!isOpen || !panelRef.current) return
+      const panel = panelRef.current
+      const focusableSelectors =
+        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      const handleTab = (e: KeyboardEvent) => {
+        if (e.key !== 'Tab') return
+        const focusables = Array.from(panel.querySelectorAll<HTMLElement>(focusableSelectors))
+        if (!focusables.length) return
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            last.focus()
+            e.preventDefault()
+          }
+        } else {
+          if (document.activeElement === last) {
+            first.focus()
+            e.preventDefault()
+          }
+        }
+      }
+      panel.addEventListener('keydown', handleTab)
+      return () => panel.removeEventListener('keydown', handleTab)
+    }, [isOpen])
 
-  return (
-    <AnimatePresence>
-      {isOpen && (
-        <div
-          className="fixed inset-0 z-modal flex items-center justify-center p-4"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Connect wallet"
-        >
-          {/* Backdrop with blur */}
-          <motion.div
-            variants={backdropVariants}
-            initial="hidden"
-            animate="visible"
-            exit="exit"
-            className="absolute inset-0 bg-surface-950/60 backdrop-blur-sm"
-            onClick={onClose}
-            aria-hidden="true"
-          />
+    const handleWalletSelect = useCallback(
+      async (walletType: WalletType) => {
+        setSelectedWallet(walletType)
+        setConnectionState('connecting')
+        setStatusMessage('Connecting to wallet...')
 
-          {/* Modal panel */}
-          <motion.div
-            ref={panelRef}
-            variants={modalVariants}
-            initial="hidden"
-            animate="visible"
-            exit="exit"
-            tabIndex={-1}
-            className="
+        const result = await connect({
+          walletType,
+          network: selectedNetwork,
+        })
+
+        if (result.success) {
+          setConnectionState('success')
+          setStatusMessage('Connected successfully')
+          if (result.address && onConnect) {
+            onConnect(result.address)
+          }
+          // Auto-close after success
+          setTimeout(() => onClose(), 1200)
+        } else {
+          setConnectionState('error')
+          const msg = result.error?.message || 'Connection failed. Please try again.'
+          setStatusMessage(msg)
+          if (onError && result.error) {
+            onError(result.error.message)
+          }
+        }
+      },
+      [connect, selectedNetwork, onConnect, onError, onClose]
+    )
+
+    // Filter to Freighter and Lobstr only (per issue requirements)
+    const supportedWallets = availableWallets.filter(
+      (w: WalletInfo) => w.type === 'freighter' || w.type === 'lobstr'
+    )
+
+    return (
+      <AnimatePresence>
+        {isOpen && (
+          <div
+            className="fixed inset-0 z-modal flex items-center justify-center overflow-y-auto p-4"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Connect wallet"
+          >
+            {/* Backdrop with blur */}
+            <motion.div
+              variants={backdropVariants}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+              className="absolute inset-0 bg-surface-950/60 backdrop-blur-sm"
+              onClick={onClose}
+              aria-hidden="true"
+            />
+
+            {/* Modal panel */}
+            <motion.div
+              ref={panelRef}
+              variants={modalVariants}
+              initial="hidden"
+              animate="visible"
+              exit="exit"
+              tabIndex={-1}
+              className="
               relative w-full max-w-md
               rounded-2xl overflow-hidden
               bg-white/90 dark:bg-surface-900/90
@@ -171,29 +171,29 @@ export const WalletModal: React.FC<WalletModalProps> = memo(({
               shadow-xl
               focus:outline-none
             "
-          >
-            {/* Gradient top accent */}
-            <div className="absolute inset-x-0 top-0 h-px bg-gradient-stellar" />
+            >
+              {/* Gradient top accent */}
+              <div className="absolute inset-x-0 top-0 h-px bg-gradient-stellar" />
 
-            <div className="p-6 sm:p-8">
-              {/* Header */}
-              <div className="flex items-center justify-between mb-6">
-                <div className="flex items-center gap-3">
-                  <Image
-                    src="/logo-icon.svg"
-                    alt="Soroban Ajo"
-                    width={32}
-                    height={32}
-                    className="transition-transform duration-200 hover:scale-105"
-                    priority
-                  />
-                  <h2 className="text-lg font-semibold text-surface-900 dark:text-white">
-                    Connect Wallet
-                  </h2>
-                </div>
-                <button
-                  onClick={onClose}
-                  className="
+              <div className="p-6 sm:p-8 max-h-[85vh] overflow-y-auto">
+                {/* Header */}
+                <div className="flex items-center justify-between mb-6">
+                  <div className="flex items-center gap-3">
+                    <Image
+                      src="/logo-icon.svg"
+                      alt="Soroban Ajo"
+                      width={32}
+                      height={32}
+                      className="transition-transform duration-200 hover:scale-105"
+                      priority
+                    />
+                    <h2 className="text-lg font-semibold text-surface-900 dark:text-white">
+                      Connect Wallet
+                    </h2>
+                  </div>
+                  <button
+                    onClick={onClose}
+                    className="
                     p-2 rounded-lg
                     text-surface-400 hover:text-surface-600
                     dark:text-surface-500 dark:hover:text-surface-300
@@ -201,28 +201,35 @@ export const WalletModal: React.FC<WalletModalProps> = memo(({
                     transition-colors duration-150
                     focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500
                   "
-                  aria-label="Close modal"
-                >
-                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              </div>
-
-              {/* Network selector */}
-              {showNetworkSelector && (
-                <div className="mb-5">
-                  <label
-                    htmlFor="wallet-network-select"
-                    className="block text-xs font-medium text-surface-500 dark:text-surface-400 mb-1.5"
+                    aria-label="Close modal"
                   >
-                    Network
-                  </label>
-                  <select
-                    id="wallet-network-select"
-                    value={selectedNetwork}
-                    onChange={(e) => setSelectedNetwork(e.target.value as 'testnet' | 'mainnet' | 'futurenet')}
-                    className="
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </div>
+
+                {/* Network selector */}
+                {showNetworkSelector && (
+                  <div className="mb-5">
+                    <label
+                      htmlFor="wallet-network-select"
+                      className="block text-xs font-medium text-surface-500 dark:text-surface-400 mb-1.5"
+                    >
+                      Network
+                    </label>
+                    <select
+                      id="wallet-network-select"
+                      value={selectedNetwork}
+                      onChange={(e) =>
+                        setSelectedNetwork(e.target.value as 'testnet' | 'mainnet' | 'futurenet')
+                      }
+                      className="
                       w-full px-3 py-2 rounded-lg text-sm
                       border border-surface-200 dark:border-surface-700
                       bg-white dark:bg-surface-800
@@ -230,78 +237,79 @@ export const WalletModal: React.FC<WalletModalProps> = memo(({
                       focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500
                       transition-colors duration-150
                     "
-                  >
-                    <option value="testnet">Testnet</option>
-                    <option value="mainnet">Mainnet</option>
-                    <option value="futurenet">Futurenet</option>
-                  </select>
-                </div>
-              )}
-
-              {/* Connection status */}
-              <AnimatePresence>
-                {connectionState !== 'idle' && (
-                  <div className="mb-4">
-                    <ConnectionStatus state={connectionState} message={statusMessage} />
+                    >
+                      <option value="testnet">Testnet</option>
+                      <option value="mainnet">Mainnet</option>
+                      <option value="futurenet">Futurenet</option>
+                    </select>
                   </div>
                 )}
-              </AnimatePresence>
 
-              {/* Wallet list */}
-              <motion.div
-                variants={walletListVariants}
-                initial="hidden"
-                animate="visible"
-                className="space-y-3"
-              >
-                <p className="text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wider">
-                  Choose a wallet
-                </p>
-                {supportedWallets.map((wallet: WalletInfo) => (
-                  <WalletCard
-                    key={wallet.type}
-                    name={wallet.name}
-                    type={wallet.type}
-                    isInstalled={wallet.isInstalled}
-                    isLoading={isLoading}
-                    isSelected={selectedWallet === wallet.type}
-                    onSelect={handleWalletSelect}
-                  />
-                ))}
-              </motion.div>
+                {/* Connection status */}
+                <AnimatePresence>
+                  {connectionState !== 'idle' && (
+                    <div className="mb-4">
+                      <ConnectionStatus state={connectionState} message={statusMessage} />
+                    </div>
+                  )}
+                </AnimatePresence>
 
-              {/* No wallets installed hint */}
-              {supportedWallets.every((w: WalletInfo) => !w.isInstalled) && (
-                <motion.p
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  className="mt-4 text-xs text-center text-surface-500 dark:text-surface-400"
+                {/* Wallet list */}
+                <motion.div
+                  variants={walletListVariants}
+                  initial="hidden"
+                  animate="visible"
+                  className="space-y-3"
                 >
-                  Install a supported wallet extension to continue.
-                </motion.p>
-              )}
+                  <p className="text-xs font-medium text-surface-500 dark:text-surface-400 uppercase tracking-wider">
+                    Choose a wallet
+                  </p>
+                  {supportedWallets.map((wallet: WalletInfo) => (
+                    <WalletCard
+                      key={wallet.type}
+                      name={wallet.name}
+                      type={wallet.type}
+                      isInstalled={wallet.isInstalled}
+                      isLoading={isLoading}
+                      isSelected={selectedWallet === wallet.type}
+                      onSelect={handleWalletSelect}
+                    />
+                  ))}
+                </motion.div>
 
-              {/* Error from hook */}
-              <AnimatePresence>
-                {error && connectionState === 'idle' && (
-                  <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: 'auto' }}
-                    exit={{ opacity: 0, height: 0 }}
-                    className="mt-4 p-3 rounded-xl bg-error-50 dark:bg-error-500/10 border border-error-100 dark:border-error-700"
-                    role="alert"
-                    aria-live="polite"
+                {/* No wallets installed hint */}
+                {supportedWallets.every((w: WalletInfo) => !w.isInstalled) && (
+                  <motion.p
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    className="mt-4 text-xs text-center text-surface-500 dark:text-surface-400"
                   >
-                    <p className="text-sm text-error-700 dark:text-error-500">{error.message}</p>
-                  </motion.div>
+                    Install a supported wallet extension to continue.
+                  </motion.p>
                 )}
-              </AnimatePresence>
-            </div>
-          </motion.div>
-        </div>
-      )}
-    </AnimatePresence>
-  );
-});
 
-WalletModal.displayName = 'WalletModal';
+                {/* Error from hook */}
+                <AnimatePresence>
+                  {error && connectionState === 'idle' && (
+                    <motion.div
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: 'auto' }}
+                      exit={{ opacity: 0, height: 0 }}
+                      className="mt-4 p-3 rounded-xl bg-error-50 dark:bg-error-500/10 border border-error-100 dark:border-error-700"
+                      role="alert"
+                      aria-live="polite"
+                    >
+                      <p className="text-sm text-error-700 dark:text-error-500">{error.message}</p>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
+    )
+  }
+)
+
+WalletModal.displayName = 'WalletModal'


### PR DESCRIPTION
## Summary

Fixes the "wallet selection popup can't scroll, it's static" report.

`AppLayout` renders `WalletConnector` for the "Connect Wallet" popup (`WalletModal`/`WalletConnect` are unreferenced from anywhere reachable). Its wallet-selection panel was centered with `fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2` and had no `max-height` or `overflow-y` — on any viewport shorter than the panel's content (wallet list + install-wallet hint box, or the 2FA code entry view), the excess just clipped off both the top and bottom of the screen with no way to reach it, since neither the panel nor its fixed backdrop container could scroll.

## Fix
- Added `max-h-[85vh] overflow-y-auto` to `WalletConnector`'s selection panel.
- Applied the same pattern to `WalletModal` (adjacent, currently-unreachable component with the identical latent bug) for consistency, plus `overflow-y-auto` on its outer backdrop container.
