### PR TITLE
fix: replace fragile transform-centering on wallet modal

### DIFF
--- a/frontend/src/components/WalletConnector.tsx
+++ b/frontend/src/components/WalletConnector.tsx
@@ -168,17 +168,17 @@ export const WalletConnector: React.FC = () => {
 
         {/* Wallet Selection Modal */}
         {(showWalletSelection || pendingTwoFactor) && (
-          <>
-            <div
-              className="fixed inset-0 bg-black/50 z-50"
-              onClick={() => {
-                if (pendingTwoFactor) {
-                  cancelTwoFactor()
-                }
-                setShowWalletSelection(false)
-              }}
-            />
-            <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-800 rounded-xl shadow-2xl p-6 w-full max-w-md max-h-[85vh] overflow-y-auto z-50">
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center overflow-y-auto bg-black/50 p-4"
+            onClick={(event) => {
+              if (event.target !== event.currentTarget) return
+              if (pendingTwoFactor) {
+                cancelTwoFactor()
+              }
+              setShowWalletSelection(false)
+            }}
+          >
+            <div className="my-auto max-h-[85vh] w-full max-w-md overflow-y-auto rounded-xl bg-white p-6 shadow-2xl dark:bg-gray-800">
               <div className="flex items-center justify-between mb-6">
                 <h3 className="text-xl font-bold text-gray-900 dark:text-white">
                   {pendingTwoFactor ? 'Enter authentication code' : 'Select Wallet'}
@@ -323,7 +323,7 @@ export const WalletConnector: React.FC = () => {
                 </>
               )}
             </div>
-          </>
+          </div>
         )}
 
         {connectError && (


### PR DESCRIPTION
## Summary

Follow-up to #782, which didn't actually fix the issue — after deploying it, the wallet-selection modal ended up pinned to the top of the screen with no working scroll.

## Root cause

#782 added `max-h-[85vh] overflow-y-auto` directly onto a panel positioned with `fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2`. That combination is unreliable: transform-based centering computes its offset from the element's own box, and once that box becomes a max-height/scroll container, browsers don't consistently recompute the translate against the constrained height — in practice this pinned the panel to the top of the viewport with no usable scroll.

## Fix

Replaced it with the same standard flex-centered-overlay pattern already used correctly in `WalletModal.tsx`: a single `fixed inset-0 flex items-center justify-center overflow-y-auto` container (also acting as the click-outside-to-close backdrop, keyed off `event.target === currentTarget` instead of a separate backdrop div) with a plain, non-positioned panel inside it. This lets normal flex layout + scroll handle centering instead of fighting a transform.

## Test plan
- [x] `next build` succeeds
- [x] `tsc --noEmit` and `eslint` clean on the changed file
- [ ] Please verify visually after deploy — I don't have a way to render/screenshot the actual popup from this environment, so this needs a real check in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)