### PR TITLE
fix: sybil/collusion-resistant reputation scoring (#802)

### DIFF
--- a/contracts/ajo/docs/reputation-sybil-analysis.md
+++ b/contracts/ajo/docs/reputation-sybil-analysis.md
@@ -130,7 +130,7 @@ a second, complementary layer.
 component's own existing "first tier of real activity" threshold) is the
 minimum per-cycle contribution amount for a group's participation to count
 toward score. `MemberStats` now tracks `qualifying_contributions`,
-`qualifying_on_time_contributions`, `qualifying_groups_completed`, and
+`qualifying_ontime_contribs`, `qualifying_groups_completed`, and
 `qualifying_amount_contributed` alongside the existing raw counters — only
 incremented when `contribution_amount >= MIN_REPUTATION_STAKE`
 (`contract.rs`: `contribute`, `contribute_with_token`, and the

--- a/contracts/ajo/docs/reputation-sybil-analysis.md
+++ b/contracts/ajo/docs/reputation-sybil-analysis.md
@@ -1,0 +1,180 @@
+# Reputation/Credit Scoring: Sybil & Collusion Analysis (Issue #802)
+
+**Scope:** `contracts/ajo/src/reputation.rs` and its call sites in `contract.rs`.
+
+## 1. The scoring formula, as implemented
+
+`compute_credit_score` (`reputation.rs`) produces a 0–1000 score from a
+member's aggregated `MemberStats`, recalculated on every contribution,
+payout, and group completion:
+
+| Component            | Weight | Formula (pre-fix)                                          |
+|-----------------------|--------|-------------------------------------------------------------|
+| Payment reliability   | 40 %   | `on_time_contributions / total_contributions × 400`         |
+| Groups completed      | 20 %   | `min(total_groups_completed, 10) × 20`                       |
+| Volume contributed    | 20 %   | tiered on `total_amount_contributed` (0 below 10 XLM, up to 200 at ≥100,000 XLM) |
+| Penalty history       | 20 %   | `(1 - late_contributions / total_contributions) × 200`       |
+
+`credit_score` maps to a tier: Unrated (0–199), Bronze (200–399), Silver
+(400–599), Gold (600–799), Platinum (800–899), Diamond (900–1000).
+`check_credit_requirement` / `get_credit_score` expose this for callers to
+gate group access or (per the issue's premise) loan terms and collateral.
+
+Three of the four components — reliability, completion, penalty — are pure
+**counts and ratios**. None of them are weighted by how much value actually
+moved. The only component sensitive to amount is volume, and it's gated on
+an absolute cumulative total, not on how much was at risk in any single
+group.
+
+The protocol's own minimum group size is 2 (`utils::validate_group_params`
+rejects `max_members < 2`), contribution amount only has to be `> 0`
+(`ContributionAmountZero`/`ContributionAmountNegative`), and cycle duration
+only has to be `> 0`.
+
+## 2. Sybil cost (pre-fix)
+
+**Cheapest attack:** a 2-member ROSCA (the protocol minimum) with a
+1-stroop contribution and a 1-second cycle / 0-second grace period, where
+the attacker controls both member addresses.
+
+A 2-member group needs exactly 2 payout cycles to reach `is_complete`. Per
+group that's:
+
+- 1× `create_group`, 1× `join_group`
+- 2× `contribute` per cycle × 2 cycles = 4× `contribute`
+- 2× `execute_payout`
+
+= **8 transactions**, and since `cycle_duration=1s`/`grace_period=0s`, each
+cycle clears as soon as the ledger timestamp advances past it — i.e. on the
+next ledger close (~5–6s on mainnet), not something an attacker can shortcut
+by submitting more transactions. Wall-clock cost for one completed group:
+**~2 ledger closes (~10–15 s)**.
+
+Scoring that one group under the pre-fix formula, for either member:
+
+```
+reliability = 2/2 × 400 = 400
+completion  = min(1, 10) × 20 = 20
+volume      = 0            (well under the 10 XLM volume floor)
+penalty     = 200           (no late contributions ever recorded)
+──────────────────────────────────────────
+score       = 620  → Gold tier, from ONE 8-tx, sub-cent group.
+```
+
+Repeating the loop across 10 such groups (they can run concurrently, so
+wall-clock stays ~10–15 s, not 10×) maxes out the completion component:
+
+```
+reliability = 400, completion = min(10,10)×20 = 200, volume = 0, penalty = 200
+──────────────────────────────────────────
+score       = 800  → Platinum tier.
+```
+
+**Transaction fees:** Soroban invocations on Stellar mainnet run a base fee
+of 100 stroops plus a modest resource fee; even generously assuming 0.01 XLM
+per invocation, 10 groups × 8 tx = 80 tx ≈ **0.8 XLM** in fees (a few US
+cents to well under a dollar at any XLM price the asset has historically
+traded at).
+
+**Account cost:** the attacker needs their own identity plus exactly **one**
+disposable helper address (the same helper can be reused as the second
+member across all 10 groups — nothing prevents one address from belonging to
+many groups at once). Stellar's minimum account reserve (~1 XLM per account)
+is refundable via `merge_account` once the helper is discarded, so it's
+locked capital during the attack, not a sunk cost.
+
+**Bottom line: for well under $1 and about 10–15 seconds, one actor mints a
+Platinum-tier (800/1000) identity, and this scales linearly and in parallel
+— N identities cost N× the fees and N helper accounts, with no increase in
+per-identity cost.** Any product decision that gates better loan terms or
+reduced collateral behind this score was gating them behind a cost lower
+than the gas to read this document.
+
+## 3. Collusion resistance (pre-fix)
+
+The same loop works for two *real, distinct* accounts that agree offline to
+farm each other's score, with no sybil-detection heuristic (distinct
+addresses, distinct funding sources, whatever) able to tell it apart from
+genuine participation: the pre-fix formula doesn't distinguish "two people
+who don't trust each other contributing real capital for 10 cycles" from
+"two people rotating the same handful of stroops back and forth." Because
+reliability/completion/penalty are amount-blind, colluders don't even need
+real capital — the dust-amount version above works identically for two real
+people as it does for two sybils. No default risk is ever taken by either
+party: each payout simply returns capital the recipient contributed moments
+earlier in the same cycle.
+
+## 4. Mitigation chosen: minimum stake-at-risk per qualifying cycle
+
+Of the options the issue lists, the other two aren't viable right now:
+
+- **Cross-referencing the insurance subsystem's risk data** — `insurance.rs`
+  `get_member_risk_score`/`get_group_risk_rating` are unimplemented stubs
+  that return a constant (see issue #800); there's no real risk signal yet
+  to cross-reference.
+- **Graph-based collusion detection** (flagging reciprocal group clusters)
+  is real anti-sybil tooling, but it's an off-chain analytics job, not
+  something `reputation.rs`'s pure, cheap, per-call score computation can
+  do on-chain without unbounded storage/compute — a much larger initiative
+  than this issue's scope.
+
+That leaves **score decay/recency weighting** and **minimum stake-at-risk
+thresholds**. We implemented the latter: it directly targets the mechanism
+that makes the attack cheap (amount-blind scoring), is a small, local,
+fully-testable change, and doesn't preclude adding decay weighting later as
+a second, complementary layer.
+
+### Implementation
+
+`reputation::MIN_REPUTATION_STAKE` (`= 10 XLM`, matching the volume
+component's own existing "first tier of real activity" threshold) is the
+minimum per-cycle contribution amount for a group's participation to count
+toward score. `MemberStats` now tracks `qualifying_contributions`,
+`qualifying_on_time_contributions`, `qualifying_groups_completed`, and
+`qualifying_amount_contributed` alongside the existing raw counters — only
+incremented when `contribution_amount >= MIN_REPUTATION_STAKE`
+(`contract.rs`: `contribute`, `contribute_with_token`, and the
+group-completion blocks in `execute_payout` / `execute_multi_token_payout`).
+`compute_credit_score` now derives all four components from the qualifying
+figures instead of the raw ones. Groups below the threshold are otherwise
+unaffected — they still work exactly as before, they simply generate no
+reputation.
+
+Re-scoring the attack in §2 against the new formula: `qualifying_contributions`
+stays 0 throughout (1 stroop `<` 10 XLM), so the score is 0 for 1 group and
+still 0 for 10. See `tests/reputation_sybil_tests.rs` for the executable
+version of this, alongside a positive-path test confirming a group that
+actually stakes ≥10 XLM per cycle scores normally (660/1000 for one
+completed 2-member group at exactly the threshold).
+
+### What this does and doesn't fix
+
+- **Fixes:** the practically-free, unlimited-scale version of the attack.
+  Before, cost was independent of the score achieved. After, reaching any
+  non-zero score requires locking real capital (≥10 XLM) per qualifying
+  cycle — a five-to-six order of magnitude cost increase over the 1-stroop
+  version, and it removes the free ride on the completion-count cap.
+- **Doesn't fully fix:** an attacker who already has ~10 XLM of liquid
+  capital can still recycle the *same* capital through a chain of sybil
+  identities *serially* (one identity's group completes, the capital frees
+  up, feed it into the next identity's group), so this raises the cost of
+  running the attack **in parallel** (capital-multiplied) but only rate-
+  limits — via wall-clock cycle time — an attacker willing to run it
+  **serially** with a fixed amount of capital. It also doesn't (yet) address
+  multi-token groups where a token's raw integer amount could nominally
+  clear the stroop-denominated threshold while representing negligible real
+  value (an existing limitation of `volume_score` too, not introduced here).
+
+### Recommended follow-up
+
+- **Recency/decay weighting**, so a score built once and never
+  refreshed decays — directly limits the serial-recycling residual above by
+  forcing sustained capital commitment rather than a one-time build-up.
+  Complementary to a distinct-counterparty-diversity requirement (e.g.
+  discounting qualifying activity concentrated in a small, repeatedly-reused
+  set of counterparties), which would address collusion between a small,
+  fixed cartel more directly than a stake floor alone.
+- Once #800 lands real risk scoring in `insurance.rs`, cross-referencing it
+  here becomes viable and would catch cases a pure stake floor can't (a
+  well-capitalized cartel that meets the stake floor but has an
+  anomalous claims/default pattern).

--- a/contracts/ajo/src/contract.rs
+++ b/contracts/ajo/src/contract.rs
@@ -480,6 +480,13 @@ impl AjoContract {
         stats.total_contributions += 1;
         stats.on_time_contributions += 1;
         stats.total_amount_contributed += contribution_amount;
+        // Only count this contribution toward the credit score if the group
+        // has real stake at risk per cycle (see reputation::MIN_REPUTATION_STAKE).
+        if contribution_amount >= crate::reputation::MIN_REPUTATION_STAKE {
+            stats.qualifying_contributions += 1;
+            stats.qualifying_on_time_contributions += 1;
+            stats.qualifying_amount_contributed += contribution_amount;
+        }
         storage::store_member_stats(&env, &member, &stats);
 
         // Check and record member achievements
@@ -677,10 +684,14 @@ impl AjoContract {
 
         // If group completed, update member stats for all members
         if group.is_complete {
+            let qualifies = group.contribution_amount >= crate::reputation::MIN_REPUTATION_STAKE;
             for member in group.members.iter() {
                 let mut stats = storage::get_member_stats(&env, &member)
                     .unwrap_or_else(|| utils::default_member_stats(&env, &member));
                 stats.total_groups_completed += 1;
+                if qualifies {
+                    stats.qualifying_groups_completed += 1;
+                }
                 storage::store_member_stats(&env, &member, &stats);
                 // Update reputation for all members on group completion
                 let _ = crate::reputation::update_member_reputation(&env, &member);
@@ -2167,6 +2178,11 @@ pub fn get_refund_record(
         stats.total_contributions += 1;
         stats.on_time_contributions += 1;
         stats.total_amount_contributed += required_amount;
+        if required_amount >= crate::reputation::MIN_REPUTATION_STAKE {
+            stats.qualifying_contributions += 1;
+            stats.qualifying_on_time_contributions += 1;
+            stats.qualifying_amount_contributed += required_amount;
+        }
         storage::store_member_stats(&env, &member, &stats);
 
         Ok(())
@@ -2293,10 +2309,14 @@ pub fn get_refund_record(
         }
 
         if group.is_complete {
+            let qualifies = group.contribution_amount >= crate::reputation::MIN_REPUTATION_STAKE;
             for m in group.members.iter() {
                 let mut stats = storage::get_member_stats(&env, &m)
                     .unwrap_or_else(|| utils::default_member_stats(&env, &m));
                 stats.total_groups_completed += 1;
+                if qualifies {
+                    stats.qualifying_groups_completed += 1;
+                }
                 storage::store_member_stats(&env, &m, &stats);
             }
         }

--- a/contracts/ajo/src/contract.rs
+++ b/contracts/ajo/src/contract.rs
@@ -484,7 +484,7 @@ impl AjoContract {
         // has real stake at risk per cycle (see reputation::MIN_REPUTATION_STAKE).
         if contribution_amount >= crate::reputation::MIN_REPUTATION_STAKE {
             stats.qualifying_contributions += 1;
-            stats.qualifying_on_time_contributions += 1;
+            stats.qualifying_ontime_contribs += 1;
             stats.qualifying_amount_contributed += contribution_amount;
         }
         storage::store_member_stats(&env, &member, &stats);
@@ -2180,7 +2180,7 @@ pub fn get_refund_record(
         stats.total_amount_contributed += required_amount;
         if required_amount >= crate::reputation::MIN_REPUTATION_STAKE {
             stats.qualifying_contributions += 1;
-            stats.qualifying_on_time_contributions += 1;
+            stats.qualifying_ontime_contribs += 1;
             stats.qualifying_amount_contributed += required_amount;
         }
         storage::store_member_stats(&env, &member, &stats);

--- a/contracts/ajo/src/reputation.rs
+++ b/contracts/ajo/src/reputation.rs
@@ -96,7 +96,7 @@ pub fn compute_credit_score(stats: &crate::types::MemberStats) -> u32 {
     }
 
     // 1. Payment reliability component (0–400)
-    let reliability = (stats.qualifying_on_time_contributions * 400) / qualifying_total;
+    let reliability = (stats.qualifying_ontime_contribs * 400) / qualifying_total;
 
     // 2. Groups completed component (0–200): cap at 10 completed groups
     let completed_capped = stats.qualifying_groups_completed.min(10);

--- a/contracts/ajo/src/reputation.rs
+++ b/contracts/ajo/src/reputation.rs
@@ -1,14 +1,31 @@
 /// On-chain reputation system for Ajo members.
 ///
 /// Credit score formula (0–1000 scale):
-///   - Payment reliability  40 % → on_time / total_contributions × 400
-///   - Groups completed     20 % → min(total_groups_completed, 10) × 20
-///   - Volume contributed   20 % → tiered by total_amount_contributed (stroops)
-///   - Penalty history      20 % → (1 - late_contributions / total_contributions) × 200
+///   - Payment reliability  40 % → qualifying_on_time / qualifying_contributions × 400
+///   - Groups completed     20 % → min(qualifying_groups_completed, 10) × 20
+///   - Volume contributed   20 % → tiered by qualifying_amount_contributed (stroops)
+///   - Penalty history      20 % → (1 - late_contributions / qualifying_contributions) × 200
 ///
 /// The score is recalculated and stored every time a member's stats change
 /// (contribution, payout, group completion).  Callers should invoke
 /// `update_member_reputation` after any such event.
+///
+/// ## Sybil / collusion resistance
+///
+/// Every component above is keyed off "qualifying" activity rather than raw
+/// activity counts. A contribution only qualifies — and only then moves the
+/// needle on a member's score — if the group's per-cycle contribution amount
+/// is at least [`MIN_REPUTATION_STAKE`]. Groups below that amount still work
+/// exactly as before (they can contribute, get paid out, complete), they
+/// simply don't generate any reputation.
+///
+/// This closes the cheapest sybil attack against the old formula: creating
+/// many 2-member, dust-amount ROSCA groups where the attacker controls both
+/// "members" and rotates a few stroops between them. Under the old formula
+/// that reached Platinum (800/1000) for a fraction of a cent in fees. Under
+/// this one it scores 0, because none of the activity qualifies. See
+/// `docs/reputation-sybil-analysis.md` for the full cost analysis and the
+/// tests in `tests/reputation_sybil_tests.rs` for the attack scenario.
 use soroban_sdk::{Address, Env};
 
 use crate::errors::AjoError;
@@ -17,6 +34,16 @@ use crate::types::{
     CreditScoreSnapshot, PaymentHistoryEntry, ReputationScore, ReputationTier,
 };
 use crate::utils;
+
+/// Minimum per-cycle contribution amount (in stroops) for a group's
+/// participation to count toward a member's credit score.
+///
+/// Set to 10 XLM — the same amount the volume component already treats as
+/// the first tier of "real" economic activity (see `volume_score`). Below
+/// this, a round of contribute/payout moves too little value to represent
+/// genuine stake-at-risk, so it's cheap to fabricate at scale and is
+/// excluded from scoring entirely rather than counted at a discount.
+pub const MIN_REPUTATION_STAKE: i128 = 10 * 10_000_000;
 
 // ── Score calculation ─────────────────────────────────────────────────────
 
@@ -55,29 +82,35 @@ fn tier_from_score(score: u32) -> ReputationTier {
 
 /// Computes the full credit score (0–1000) from a member's aggregated stats.
 ///
-/// Returns 0 when the member has no contribution history yet.
+/// Returns 0 when the member has no contribution history yet, and also when
+/// the member's activity exists only in groups below [`MIN_REPUTATION_STAKE`]
+/// (i.e. nothing qualifies yet — see module docs).
 pub fn compute_credit_score(stats: &crate::types::MemberStats) -> u32 {
-    let total = stats.total_contributions;
-    if total == 0 {
+    if stats.total_contributions == 0 {
+        return 0;
+    }
+
+    let qualifying_total = stats.qualifying_contributions;
+    if qualifying_total == 0 {
         return 0;
     }
 
     // 1. Payment reliability component (0–400)
-    let reliability = (stats.on_time_contributions * 400) / total;
+    let reliability = (stats.qualifying_on_time_contributions * 400) / qualifying_total;
 
     // 2. Groups completed component (0–200): cap at 10 completed groups
-    let completed_capped = stats.total_groups_completed.min(10);
+    let completed_capped = stats.qualifying_groups_completed.min(10);
     let completion = completed_capped * 20;
 
     // 3. Volume component (0–200)
-    let volume = volume_score(stats.total_amount_contributed);
+    let volume = volume_score(stats.qualifying_amount_contributed);
 
     // 4. Penalty component (0–200): penalise late contributions
     let penalty_component = if stats.late_contributions == 0 {
         200
     } else {
-        let on_time = total.saturating_sub(stats.late_contributions);
-        (on_time * 200) / total
+        let on_time = qualifying_total.saturating_sub(stats.late_contributions);
+        (on_time * 200) / qualifying_total
     };
 
     reliability + completion + volume + penalty_component

--- a/contracts/ajo/src/types.rs
+++ b/contracts/ajo/src/types.rs
@@ -572,7 +572,7 @@ pub struct MemberStats {
     /// count toward the credit score's reliability/completion/volume
     /// components, so cheap dust-amount groups can't inflate a score.
     pub qualifying_contributions: u32,
-    pub qualifying_on_time_contributions: u32,
+    pub qualifying_ontime_contribs: u32,
     pub qualifying_groups_completed: u32,
     pub qualifying_amount_contributed: i128,
     pub achievements: Vec<MemberAchievement>,

--- a/contracts/ajo/src/types.rs
+++ b/contracts/ajo/src/types.rs
@@ -567,6 +567,14 @@ pub struct MemberStats {
     pub on_time_contributions: u32,
     pub late_contributions: u32,
     pub total_amount_contributed: i128,
+    /// Contributions made in cycles where the group's per-cycle contribution
+    /// amount met [`crate::reputation::MIN_REPUTATION_STAKE`]. Only these
+    /// count toward the credit score's reliability/completion/volume
+    /// components, so cheap dust-amount groups can't inflate a score.
+    pub qualifying_contributions: u32,
+    pub qualifying_on_time_contributions: u32,
+    pub qualifying_groups_completed: u32,
+    pub qualifying_amount_contributed: i128,
     pub achievements: Vec<MemberAchievement>,
 }
 

--- a/contracts/ajo/src/utils.rs
+++ b/contracts/ajo/src/utils.rs
@@ -427,6 +427,10 @@ pub fn default_member_stats(env: &Env, member: &Address) -> crate::types::Member
         total_contributions: 0,
         on_time_contributions: 0,
         late_contributions: 0,
+        qualifying_contributions: 0,
+        qualifying_on_time_contributions: 0,
+        qualifying_groups_completed: 0,
+        qualifying_amount_contributed: 0,
         total_amount_contributed: 0,
         achievements: Vec::new(env),
     }

--- a/contracts/ajo/src/utils.rs
+++ b/contracts/ajo/src/utils.rs
@@ -428,7 +428,7 @@ pub fn default_member_stats(env: &Env, member: &Address) -> crate::types::Member
         on_time_contributions: 0,
         late_contributions: 0,
         qualifying_contributions: 0,
-        qualifying_on_time_contributions: 0,
+        qualifying_ontime_contribs: 0,
         qualifying_groups_completed: 0,
         qualifying_amount_contributed: 0,
         total_amount_contributed: 0,

--- a/contracts/ajo/tests/reputation_sybil_tests.rs
+++ b/contracts/ajo/tests/reputation_sybil_tests.rs
@@ -1,0 +1,174 @@
+#![cfg(test)]
+
+//! Tests for the sybil/collusion mitigation in `reputation.rs` (Issue #802).
+//!
+//! The attack modeled here: an attacker creates a two-member ROSCA (the
+//! protocol's minimum group size) contributing a dust amount per cycle,
+//! with the attacker effectively controlling both "members" (or, for the
+//! collusion variant, two distinct but colluding real accounts). Before the
+//! fix, completing even one such group pushed a member's credit score to
+//! 620/1000 (Gold) purely from the reliability/completion/penalty
+//! components, none of which required any real amount at risk. See
+//! `docs/reputation-sybil-analysis.md` for the full cost breakdown.
+
+use soroban_ajo::{AjoContract, AjoContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, Env,
+};
+
+/// 10 XLM in stroops — the reputation system's minimum qualifying stake per
+/// cycle (`reputation::MIN_REPUTATION_STAKE`). Duplicated here as a literal
+/// since the constant is crate-private; keep in sync if it ever changes.
+const MIN_REPUTATION_STAKE: i128 = 100_000_000;
+
+fn setup_test_env() -> (Env, AjoContractClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, AjoContract);
+    let client = AjoContractClient::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let member2 = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = env.register_stellar_asset_contract(token_admin);
+
+    (env, client, creator, member2, token)
+}
+
+fn mint_tokens(env: &Env, token_id: &Address, members: &[Address], amount: i128) {
+    let token_client = token::StellarAssetClient::new(env, token_id);
+    for member in members {
+        token_client.mint(member, &amount);
+    }
+}
+
+/// Runs a minimal two-member ROSCA (the smallest group the protocol allows)
+/// from creation through both payout cycles, i.e. full completion. Uses a
+/// 1-second cycle with no grace period so the whole thing clears in a single
+/// ledger-timestamp bump, mirroring the cheapest possible attack loop.
+fn complete_two_member_rosca(
+    env: &Env,
+    client: &AjoContractClient,
+    creator: &Address,
+    member2: &Address,
+    token: &Address,
+    contribution_amount: i128,
+) {
+    let group_id = client.create_group(
+        creator,
+        token,
+        &contribution_amount,
+        &1u64, // cycle_duration: 1 second
+        &2u32, // max_members: protocol minimum
+        &0u64, // grace_period: none
+        &0u32, // penalty_rate
+        &0u32, // insurance_rate_bps
+    );
+
+    client.join_group(member2, &group_id);
+
+    // Cycle 1
+    client.contribute(creator, &group_id);
+    client.contribute(member2, &group_id);
+    env.ledger().with_mut(|li| li.timestamp += 2);
+    client.execute_payout(&group_id);
+
+    // Cycle 2 (group completes: payout_index reaches member_count)
+    client.contribute(creator, &group_id);
+    client.contribute(member2, &group_id);
+    env.ledger().with_mut(|li| li.timestamp += 2);
+    client.execute_payout(&group_id);
+}
+
+#[test]
+fn test_dust_self_dealing_group_does_not_inflate_score() {
+    let (env, client, creator, member2, token) = setup_test_env();
+    mint_tokens(&env, &token, &[creator.clone(), member2.clone()], 10_000i128);
+
+    // Attacker's cheapest loop: a 2-member group contributing 1 stroop per
+    // cycle, self-dealt between two addresses the attacker controls.
+    complete_two_member_rosca(&env, &client, &creator, &member2, &token, 1i128);
+
+    let stats = client.get_member_stats(&creator);
+    assert_eq!(stats.total_contributions, 2);
+    assert_eq!(stats.total_groups_completed, 1);
+    assert_eq!(stats.qualifying_contributions, 0);
+    assert_eq!(stats.qualifying_groups_completed, 0);
+
+    // Pre-fix this scored 620/1000 (Gold) from a single completed group.
+    // Post-fix, none of it qualifies, so the score stays at 0.
+    assert_eq!(client.get_credit_score(&creator), 0);
+}
+
+#[test]
+fn test_ten_dust_groups_still_yield_zero_score() {
+    let (env, client, creator, member2, token) = setup_test_env();
+    mint_tokens(&env, &token, &[creator.clone(), member2.clone()], 10_000i128);
+
+    // Pre-fix, 10 completed groups maxed out the "groups completed"
+    // component (200/200) regardless of amount, pushing a dust-farmed
+    // identity to Platinum (800/1000). Confirm the cap no longer helps.
+    for _ in 0..10 {
+        complete_two_member_rosca(&env, &client, &creator, &member2, &token, 1i128);
+    }
+
+    let stats = client.get_member_stats(&creator);
+    assert_eq!(stats.total_groups_completed, 10);
+    assert_eq!(stats.qualifying_groups_completed, 0);
+    assert_eq!(client.get_credit_score(&creator), 0);
+}
+
+#[test]
+fn test_just_below_stake_threshold_does_not_qualify() {
+    let (env, client, creator, member2, token) = setup_test_env();
+    mint_tokens(
+        &env,
+        &token,
+        &[creator.clone(), member2.clone()],
+        1_000_000_000i128,
+    );
+
+    complete_two_member_rosca(
+        &env,
+        &client,
+        &creator,
+        &member2,
+        &token,
+        MIN_REPUTATION_STAKE - 1,
+    );
+
+    assert_eq!(client.get_credit_score(&creator), 0);
+}
+
+#[test]
+fn test_legitimate_high_stake_group_earns_credit_score() {
+    let (env, client, creator, member2, token) = setup_test_env();
+    mint_tokens(
+        &env,
+        &token,
+        &[creator.clone(), member2.clone()],
+        1_000_000_000i128,
+    );
+
+    // A group that actually puts the minimum qualifying stake at risk each
+    // cycle should still earn reputation normally — the fix targets dust
+    // amounts, not legitimate participation.
+    complete_two_member_rosca(
+        &env,
+        &client,
+        &creator,
+        &member2,
+        &token,
+        MIN_REPUTATION_STAKE,
+    );
+
+    let stats = client.get_member_stats(&creator);
+    assert_eq!(stats.qualifying_contributions, 2);
+    assert_eq!(stats.qualifying_groups_completed, 1);
+
+    // reliability 400 (2/2 on-time) + completion 20 (1 group) +
+    // volume 40 (20 XLM total, in the 10-99 XLM tier) + penalty 200 = 660
+    assert_eq!(client.get_credit_score(&creator), 660);
+}


### PR DESCRIPTION
Closes #802

## Summary

`reputation.rs` scored members purely on activity counts and ratios (on-time ratio, groups-completed count, late-payment ratio), with no minimum stake requirement. Three of the four score components never looked at how much value actually moved.

**Sybil cost, pre-fix:** a 2-member ROSCA (the protocol's own minimum group size) contributing 1 stroop per cycle reached **Gold (620/1000)** after a single completed group, and **Platinum (800/1000)** after ten — for well under $1 in fees and ~10-15 seconds of wall-clock time, using one throwaway helper address reused across every group. The same loop works identically for two real, colluding accounts with no capital risk on either side.

**Fix:** a minimum qualifying stake (10 XLM/cycle — the same amount the existing volume tier already treats as "real" activity) that a group's per-cycle contribution amount must meet before its activity counts toward score. `MemberStats` now tracks `qualifying_contributions` / `qualifying_on_time_contributions` / `qualifying_groups_completed` / `qualifying_amount_contributed` alongside the existing raw counters, and `compute_credit_score` derives all four components from the qualifying figures instead. Groups below the threshold still work exactly as before (join, contribute, get paid out, complete) — they simply generate no reputation.

Full cost breakdown, the formula documentation, collusion analysis, and why the other two mitigation options in the issue (insurance risk cross-reference, graph-based collusion detection) aren't viable yet, plus disclosed residual risk (serial capital recycling) and recommended follow-up, are in [`contracts/ajo/docs/reputation-sybil-analysis.md`](contracts/ajo/docs/reputation-sybil-analysis.md).

## Changes

- `contracts/ajo/src/types.rs` — 4 new qualifying-activity fields on `MemberStats`.
- `contracts/ajo/src/utils.rs` — initialize the new fields in `default_member_stats`.
- `contracts/ajo/src/reputation.rs` — `MIN_REPUTATION_STAKE` constant; `compute_credit_score` now scores off qualifying figures.
- `contracts/ajo/src/contract.rs` — gate the qualifying increments in `contribute`, `contribute_with_token`, and both group-completion blocks (`execute_payout`, `execute_multi_token_payout`) on the group's contribution amount meeting the stake threshold.
- `contracts/ajo/docs/reputation-sybil-analysis.md` — the written analysis required by the issue.
- `contracts/ajo/tests/reputation_sybil_tests.rs` — the attack scenario (1 dust group, 10 dust groups, a just-below-threshold boundary case) asserting zero score post-fix, plus a positive-path test confirming a legitimate ≥10 XLM/cycle group still scores normally (660/1000).

## A note on verification

I was not able to get a green `cargo test` in my sandbox, for reasons that predate and are unrelated to this change:

- With no `Cargo.lock` committed (it's gitignored), a fresh dependency resolution against today's crates.io pulls in an `ed25519-dalek`/`rand_core` combination inside `soroban-env-host`'s own `testutils` that fails to compile regardless of Rust toolchain version.
- Working around that (by pinning `soroban-sdk` to exactly `21.0.0`), the crate itself then fails on `#[contracterror]`/`#[contractimpl]` macro panics (`LengthExceedsMax`) that look like the contract's accumulated spec size (loans, insurance, disputes, emergency, multisig, templates, reputation, etc.) has outgrown what `soroban-sdk` 21.x's macro can serialize — unrelated to this diff.
- Separately, `.github/workflows/ci.yml` only triggers on `main`/`develop`, but the repo's default branch is `master`, so it wouldn't run against this PR either way.

I validated the scoring arithmetic itself in an isolated harness (confirmed 0/0/660 for the three scenarios above, matching the assertions in the test file) and wrote the integration tests to the existing suite's conventions (`tests/penalty_tests.rs` etc.) so they should pass once the above pre-existing issues are resolved. Flagging per the acceptance criteria's own guidance rather than trying to fix an unrelated, much larger dependency/spec-size issue in this PR — happy to help investigate that separately if useful.

## Test plan

- [ ] `cargo test` in `contracts/ajo` once the pre-existing build issue above is resolved — expect all of `tests/reputation_sybil_tests.rs` to pass alongside the existing suite.
- [x] Reviewed the qualifying-stake wiring against every existing call site that mutates `MemberStats` (`contribute`, `contribute_with_token`, `execute_payout`, `execute_multi_token_payout`) to confirm none were missed.
- [x] Verified the score formula's arithmetic in isolation (dust attack → 0, legitimate ≥10 XLM/cycle group → 660).